### PR TITLE
Replace `mapRef` and `mapObject` names with `leafletRef` and `leafletObject`

### DIFF
--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -7,22 +7,22 @@ export default {
   name: "LControlLayers",
   props,
   setup(props) {
-    const mapRef = ref({});
+    const leafletRef = ref({});
 
     const lMethods = inject("leafLetMethods");
-    const { options, methods } = controlSetup(props, mapRef);
+    const { options, methods } = controlSetup(props, leafletRef);
     onMounted(async () => {
       const { control, setOptions } = await import(
         "leaflet/dist/leaflet-src.esm"
       );
 
-      mapRef.value = control.layers(null, null, options);
-      propsBinder(methods, mapRef.value, props, setOptions);
+      leafletRef.value = control.layers(null, null, options);
+      propsBinder(methods, leafletRef.value, props, setOptions);
 
       lMethods.registerLayerControl({
         ...props,
         ...methods,
-        mapObject: mapRef.value,
+        mapObject: leafletRef.value,
       });
     });
   },

--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -22,7 +22,7 @@ export default {
       lMethods.registerLayerControl({
         ...props,
         ...methods,
-        mapObject: leafletRef.value,
+        leafletObject: leafletRef.value,
       });
     });
   },

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -229,7 +229,7 @@ export default {
               blueprint.layersToAdd.push(layer);
             } else {
               const exist = blueprint.layersInControl.find(
-                (l) => l.mapObject._leaflet_id === layer.mapObject._leaflet_id
+                (l) => l.leafletObject._leaflet_id === layer.leafletObject._leaflet_id
               );
               if (!exist) {
                 blueprint.layerControl.addLayer(layer);
@@ -238,7 +238,7 @@ export default {
             }
           }
           if (layer.visible !== false) {
-            blueprint.leafletRef.addLayer(layer.mapObject);
+            blueprint.leafletRef.addLayer(layer.leafletObject);
           }
         },
         removeLayer(layer) {
@@ -248,18 +248,18 @@ export default {
                 (l) => l.name !== layer.name
               );
             } else {
-              blueprint.layerControl.removeLayer(layer.mapObject);
+              blueprint.layerControl.removeLayer(layer.leafletObject);
               blueprint.layersInControl = blueprint.layersInControl.filter(
-                (l) => l.mapObject._leaflet_id !== layer.mapObject._leaflet_id
+                (l) => l.leafletObject._leaflet_id !== layer.leafletObject._leaflet_id
               );
             }
           }
-          blueprint.leafletRef.removeLayer(layer.mapObject);
+          blueprint.leafletRef.removeLayer(layer.leafletObject);
         },
 
         registerLayerControl(lControlLayer) {
           blueprint.layerControl = lControlLayer;
-          blueprint.leafletRef.addControl(lControlLayer.mapObject);
+          blueprint.leafletRef.addControl(lControlLayer.leafletObject);
           blueprint.layersToAdd.forEach((layer) => {
             blueprint.layerControl.addLayer(layer);
           });
@@ -355,9 +355,9 @@ export default {
       }
     });
 
-    const mapObject = computed(() => blueprint.leafletRef);
+    const leafletObject = computed(() => blueprint.leafletRef);
     const ready = computed(() => blueprint.ready);
-    return { root, ready, mapObject };
+    return { root, ready, leafletObject };
   },
 };
 </script>

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -144,7 +144,7 @@ export default {
     const root = ref(null);
     const blueprint = reactive({
       ready: false,
-      mapRef: {},
+      leafletRef: {},
       layersToAdd: [],
       layersInControl: [],
     });
@@ -182,18 +182,18 @@ export default {
          * Triggers when zoom is updated
          * @type {number,string}
          */
-        context.emit("update:zoom", blueprint.mapRef.getZoom());
+        context.emit("update:zoom", blueprint.leafletRef.getZoom());
         /**
          * Triggers when center is updated
          * @type {object,array}
          */
-        context.emit("update:center", blueprint.mapRef.getCenter());
+        context.emit("update:center", blueprint.leafletRef.getCenter());
 
         /**
          * Triggers when bounds are updated
          * @type {object}
          */
-        context.emit("update:bounds", blueprint.mapRef.getBounds());
+        context.emit("update:bounds", blueprint.leafletRef.getBounds());
       },
       overlayAddHandler(e) {
         const layer = blueprint.layersInControl.find((l) => l.name === e.name);
@@ -238,7 +238,7 @@ export default {
             }
           }
           if (layer.visible !== false) {
-            blueprint.mapRef.addLayer(layer.mapObject);
+            blueprint.leafletRef.addLayer(layer.mapObject);
           }
         },
         removeLayer(layer) {
@@ -254,12 +254,12 @@ export default {
               );
             }
           }
-          blueprint.mapRef.removeLayer(layer.mapObject);
+          blueprint.leafletRef.removeLayer(layer.mapObject);
         },
 
         registerLayerControl(lControlLayer) {
           blueprint.layerControl = lControlLayer;
-          blueprint.mapRef.addControl(lControlLayer.mapObject);
+          blueprint.leafletRef.addControl(lControlLayer.mapObject);
           blueprint.layersToAdd.forEach((layer) => {
             blueprint.layerControl.addLayer(layer);
           });
@@ -267,7 +267,7 @@ export default {
         },
 
         setZoom(newVal) {
-          blueprint.mapRef.setZoom(newVal, {
+          blueprint.leafletRef.setZoom(newVal, {
             animate: props.noBlockingAnimations ? false : null,
           });
         },
@@ -282,15 +282,15 @@ export default {
           blueprint.padding = newVal;
         },
         setCrs(newVal) {
-          const prevBounds = blueprint.mapRef.getBounds();
-          blueprint.mapRef.options.crs = newVal;
-          blueprint.mapRef.fitBounds(prevBounds, {
+          const prevBounds = blueprint.leafletRef.getBounds();
+          blueprint.leafletRef.options.crs = newVal;
+          blueprint.leafletRef.fitBounds(prevBounds, {
             animate: false,
             padding: [0, 0],
           });
         },
         fitBounds(bounds) {
-          blueprint.mapRef.fitBounds(bounds, {
+          blueprint.leafletRef.fitBounds(bounds, {
             animate: this.noBlockingAnimations ? false : null,
           });
         },
@@ -303,11 +303,11 @@ export default {
             return;
           }
           const oldBounds =
-            blueprint.lastSetBounds || blueprint.mapRef.getBounds();
+            blueprint.lastSetBounds || blueprint.leafletRef.getBounds();
           const boundsChanged = !oldBounds.equals(newBounds, 0); // set maxMargin to 0 - check exact equals
           if (boundsChanged) {
             blueprint.lastSetBounds = newBounds;
-            blueprint.mapRef.fitBounds(newBounds, this.fitBoundsOptions);
+            blueprint.leafletRef.fitBounds(newBounds, this.fitBoundsOptions);
           }
         },
 
@@ -317,13 +317,13 @@ export default {
           }
           const newCenter = latLng(newVal);
           const oldCenter =
-            blueprint.lastSetCenter || blueprint.mapRef.getCenter();
+            blueprint.lastSetCenter || blueprint.leafletRef.getCenter();
           if (
             oldCenter.lat !== newCenter.lat ||
             oldCenter.lng !== newCenter.lng
           ) {
             blueprint.lastSetCenter = newCenter;
-            blueprint.mapRef.panTo(newCenter, {
+            blueprint.leafletRef.panTo(newCenter, {
               animate: this.noBlockingAnimations ? false : null,
             });
           }
@@ -334,28 +334,28 @@ export default {
       schematics.removeLayer = methods.removeLayer;
       schematics.registerLayerControl = methods.registerLayerControl;
 
-      blueprint.mapRef = map(root.value, options);
+      blueprint.leafletRef = map(root.value, options);
 
-      propsBinder(methods, blueprint.mapRef, props, setOptions);
+      propsBinder(methods, blueprint.leafletRef, props, setOptions);
       const listeners = remapEvents(context.attrs);
 
-      blueprint.mapRef.on(
+      blueprint.leafletRef.on(
         "moveend",
         debounce(eventHandlers.moveEndHandler, 100)
       );
-      blueprint.mapRef.on("overlayadd", eventHandlers.overlayAddHandler);
-      blueprint.mapRef.on("overlayremove", eventHandlers.overlayRemoveHandler);
-      DomEvent.on(blueprint.mapRef, listeners);
+      blueprint.leafletRef.on("overlayadd", eventHandlers.overlayAddHandler);
+      blueprint.leafletRef.on("overlayremove", eventHandlers.overlayRemoveHandler);
+      DomEvent.on(blueprint.leafletRef, listeners);
       blueprint.ready = true;
     });
 
     onBeforeUnmount(() => {
-      if (blueprint.mapRef) {
-        blueprint.mapRef.remove();
+      if (blueprint.leafletRef) {
+        blueprint.leafletRef.remove();
       }
     });
 
-    const mapObject = computed(() => blueprint.mapRef);
+    const mapObject = computed(() => blueprint.leafletRef);
     const ready = computed(() => blueprint.ready);
     return { root, ready, mapObject };
   },

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -38,7 +38,7 @@ export default {
 
       leafletRef.value.on("move", debounce(methods.latLngSync, 100));
       propsBinder(methods, leafletRef.value, props, setOptions);
-      lMethods.addLayer({ ...props, ...methods, mapObject: leafletRef.value });
+      lMethods.addLayer({ ...props, ...methods, leafletObject: leafletRef.value });
       ready.value = true;
     });
     return { ready };

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -10,7 +10,7 @@ export default {
   name: "LMarker",
   props,
   setup(props, context) {
-    const mapRef = ref({});
+    const leafletRef = ref({});
     const ready = ref(false);
 
     const schematics = reactive({
@@ -20,7 +20,7 @@ export default {
     const lMethods = inject("leafLetMethods");
     const { options, methods } = markerSetup(
       props,
-      mapRef,
+      leafletRef,
       context,
       schematics
     );
@@ -31,14 +31,14 @@ export default {
       );
       schematics.latLng = latLng;
 
-      mapRef.value = marker(props.latLng, options);
+      leafletRef.value = marker(props.latLng, options);
 
       const listeners = remapEvents(context.attrs);
-      DomEvent.on(mapRef.value, listeners);
+      DomEvent.on(leafletRef.value, listeners);
 
-      mapRef.value.on("move", debounce(methods.latLngSync, 100));
-      propsBinder(methods, mapRef.value, props, setOptions);
-      lMethods.addLayer({ ...props, ...methods, mapObject: mapRef.value });
+      leafletRef.value.on("move", debounce(methods.latLngSync, 100));
+      propsBinder(methods, leafletRef.value, props, setOptions);
+      lMethods.addLayer({ ...props, ...methods, mapObject: leafletRef.value });
       ready.value = true;
     });
     return { ready };

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -6,22 +6,22 @@ import { props, setup as tileLayerSetup } from "../functions/tileLayer";
 export default {
   props,
   setup(props, context) {
-    const mapRef = ref({});
+    const leafletRef = ref({});
     const lMethods = inject("leafLetMethods");
 
-    const { options, methods } = tileLayerSetup(props, mapRef);
+    const { options, methods } = tileLayerSetup(props, leafletRef);
 
     onMounted(async () => {
       const { tileLayer, DomEvent, setOptions } = await import(
         "leaflet/dist/leaflet-src.esm"
       );
-      mapRef.value = tileLayer(props.url, options);
+      leafletRef.value = tileLayer(props.url, options);
 
       const listeners = remapEvents(context.attrs);
-      DomEvent.on(mapRef.value, listeners);
+      DomEvent.on(leafletRef.value, listeners);
 
-      propsBinder(methods, mapRef.value, props, setOptions);
-      lMethods.addLayer({ ...props, ...methods, mapObject: mapRef.value });
+      propsBinder(methods, leafletRef.value, props, setOptions);
+      lMethods.addLayer({ ...props, ...methods, mapObject: leafletRef.value });
     });
   },
   render() {

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -21,7 +21,7 @@ export default {
       DomEvent.on(leafletRef.value, listeners);
 
       propsBinder(methods, leafletRef.value, props, setOptions);
-      lMethods.addLayer({ ...props, ...methods, mapObject: leafletRef.value });
+      lMethods.addLayer({ ...props, ...methods, leafletObject: leafletRef.value });
     });
   },
   render() {

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -27,7 +27,7 @@ export default {
       const listeners = remapEvents(context.attrs);
       DomEvent.on(leafletRef.value, listeners);
       leafletRef.value.setContent(props.content || root.value);
-      lMethods.bindTooltip({ mapObject: leafletRef.value });
+      lMethods.bindTooltip({ leafletObject: leafletRef.value });
     });
     return { root };
   },

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -10,24 +10,24 @@ export default {
   name: "LTooltip",
   props,
   setup(props, context) {
-    const mapRef = ref({});
+    const leafletRef = ref({});
     const root = ref(null);
 
     const lMethods = inject("leafLetMethods");
-    const { options, methods } = tooltipSetup(props, mapRef, context, lMethods);
+    const { options, methods } = tooltipSetup(props, leafletRef, context, lMethods);
 
     onMounted(async () => {
       const { tooltip, DomEvent, setOptions } = await import(
         "leaflet/dist/leaflet-src.esm"
       );
 
-      mapRef.value = tooltip(options);
+      leafletRef.value = tooltip(options);
 
-      propsBinder(methods, mapRef.value, props, setOptions);
+      propsBinder(methods, leafletRef.value, props, setOptions);
       const listeners = remapEvents(context.attrs);
-      DomEvent.on(mapRef.value, listeners);
-      mapRef.value.setContent(props.content || root.value);
-      lMethods.bindTooltip({ mapObject: mapRef.value });
+      DomEvent.on(leafletRef.value, listeners);
+      leafletRef.value.setContent(props.content || root.value);
+      lMethods.bindTooltip({ mapObject: leafletRef.value });
     });
     return { root };
   },

--- a/src/functions/control.js
+++ b/src/functions/control.js
@@ -6,10 +6,10 @@ export const props = {
     default: "topright",
   },
 };
-export const setup = (mapRef) => {
+export const setup = (leafletRef) => {
   onUnmounted(() => {
-    if (mapRef.value) {
-      mapRef.value.remove();
+    if (leafletRef.value) {
+      leafletRef.value.remove();
     }
   });
 };

--- a/src/functions/controlLayers.js
+++ b/src/functions/controlLayers.js
@@ -37,13 +37,13 @@ export const setup = (props, leafletRef) => {
   const methods = {
     addLayer(layer) {
       if (layer.layerType === "base") {
-        leafletRef.value.addBaseLayer(layer.mapObject, layer.name);
+        leafletRef.value.addBaseLayer(layer.leafletObject, layer.name);
       } else if (layer.layerType === "overlay") {
-        leafletRef.value.addOverlay(layer.mapObject, layer.name);
+        leafletRef.value.addOverlay(layer.leafletObject, layer.name);
       }
     },
     removeLayer(layer) {
-      leafletRef.value.removeLayer(layer.mapObject);
+      leafletRef.value.removeLayer(layer.leafletObject);
     },
   };
   return { options, methods };

--- a/src/functions/controlLayers.js
+++ b/src/functions/controlLayers.js
@@ -24,8 +24,8 @@ export const props = {
   },
 };
 
-export const setup = (props, mapRef) => {
-  controlSetup(mapRef);
+export const setup = (props, leafletRef) => {
+  controlSetup(leafletRef);
   const options = {
     collapsed: props.collapsed,
     autoZIndex: props.autoZIndex,
@@ -37,13 +37,13 @@ export const setup = (props, mapRef) => {
   const methods = {
     addLayer(layer) {
       if (layer.layerType === "base") {
-        mapRef.value.addBaseLayer(layer.mapObject, layer.name);
+        leafletRef.value.addBaseLayer(layer.mapObject, layer.name);
       } else if (layer.layerType === "overlay") {
-        mapRef.value.addOverlay(layer.mapObject, layer.name);
+        leafletRef.value.addOverlay(layer.mapObject, layer.name);
       }
     },
     removeLayer(layer) {
-      mapRef.value.removeLayer(layer.mapObject);
+      leafletRef.value.removeLayer(layer.mapObject);
     },
   };
   return { options, methods };

--- a/src/functions/gridLayer.js
+++ b/src/functions/gridLayer.js
@@ -25,10 +25,10 @@ export const props = {
   },
 };
 
-export const setup = (props, mapRef) => {
+export const setup = (props, leafletRef) => {
   const { options: layerOptions, methods: layerMethods } = layerSetup(
     props,
-    mapRef
+    leafletRef
   );
   const options = {
     ...layerOptions,

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -35,7 +35,7 @@ export const setup = (props, leafletRef, context) => {
 
   const methods = {
     setAttribution(val, old) {
-      const attributionControl = this.$parent.mapObject.attributionControl;
+      const attributionControl = this.$parent.leafletObject.attributionControl;
       attributionControl.removeAttribution(old).addAttribution(val);
     },
     setName() {
@@ -59,8 +59,8 @@ export const setup = (props, leafletRef, context) => {
         }
       }
     },
-    bindTooltip({ mapObject }) {
-      leafletRef.value.bindTooltip(mapObject);
+    bindTooltip({ leafletObject }) {
+      leafletRef.value.bindTooltip(leafletObject);
     },
     unbindTooltip() {
       const tooltip = leafletRef.value ? leafletRef.value.getTooltip() : null;
@@ -93,7 +93,7 @@ export const setup = (props, leafletRef, context) => {
   onUnmounted(() => {
     methods.unbindPopup();
     methods.unbindTooltip();
-    lMethods.removeLayer({ mapObject: leafletRef.value });
+    lMethods.removeLayer({ leafletObject: leafletRef.value });
   });
 
   return { options, methods };

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -26,7 +26,7 @@ export const props = {
   },
 };
 
-export const setup = (props, mapRef, context) => {
+export const setup = (props, leafletRef, context) => {
   const lMethods = inject("leafLetMethods");
   const options = {
     attribution: props.attribution,
@@ -39,37 +39,37 @@ export const setup = (props, mapRef, context) => {
       attributionControl.removeAttribution(old).addAttribution(val);
     },
     setName() {
-      lMethods.removeLayer(mapRef.value);
+      lMethods.removeLayer(leafletRef.value);
       if (props.visible) {
-        lMethods.addLayer(mapRef.value);
+        lMethods.addLayer(leafletRef.value);
       }
     },
     setLayerType() {
-      lMethods.removeLayer(mapRef.value);
+      lMethods.removeLayer(leafletRef.value);
       if (props.visible) {
-        lMethods.addLayer(mapRef.value);
+        lMethods.addLayer(leafletRef.value);
       }
     },
     setVisible(isVisible) {
-      if (mapRef.value) {
+      if (leafletRef.value) {
         if (isVisible) {
-          lMethods.addLayer(mapRef.value);
+          lMethods.addLayer(leafletRef.value);
         } else {
-          lMethods.removeLayer(mapRef.value);
+          lMethods.removeLayer(leafletRef.value);
         }
       }
     },
     bindTooltip({ mapObject }) {
-      mapRef.value.bindTooltip(mapObject);
+      leafletRef.value.bindTooltip(mapObject);
     },
     unbindTooltip() {
-      const tooltip = mapRef.value ? mapRef.value.getTooltip() : null;
+      const tooltip = leafletRef.value ? leafletRef.value.getTooltip() : null;
       if (tooltip) {
         tooltip.unbindTooltip();
       }
     },
     unbindPopup() {
-      const popup = mapRef.value ? mapRef.value.getPopup() : null;
+      const popup = leafletRef.value ? leafletRef.value.getPopup() : null;
       if (popup) {
         popup.unbindPopup();
       }
@@ -93,7 +93,7 @@ export const setup = (props, mapRef, context) => {
   onUnmounted(() => {
     methods.unbindPopup();
     methods.unbindTooltip();
-    lMethods.removeLayer({ mapObject: mapRef.value });
+    lMethods.removeLayer({ mapObject: leafletRef.value });
   });
 
   return { options, methods };

--- a/src/functions/marker.js
+++ b/src/functions/marker.js
@@ -27,10 +27,10 @@ export const props = {
   },
 };
 
-export const setup = (props, mapRef, context, leafletMethods) => {
+export const setup = (props, leafletRef, context, leafletMethods) => {
   const { options: layerOptions, methods: layerMethods } = layerSetup(
     props,
-    mapRef,
+    leafletRef,
     context
   );
   const options = {
@@ -41,10 +41,10 @@ export const setup = (props, mapRef, context, leafletMethods) => {
   const methods = {
     ...layerMethods,
     setDraggable(value) {
-      if (mapRef.value.dragging) {
+      if (leafletRef.value.dragging) {
         value
-          ? mapRef.value.dragging.enable()
-          : mapRef.value.dragging.disable();
+          ? leafletRef.value.dragging.enable()
+          : leafletRef.value.dragging.disable();
       }
     },
     latLngSync(event) {
@@ -56,14 +56,14 @@ export const setup = (props, mapRef, context, leafletMethods) => {
         return;
       }
 
-      if (mapRef.value) {
-        const oldLatLng = mapRef.value.getLatLng();
+      if (leafletRef.value) {
+        const oldLatLng = leafletRef.value.getLatLng();
         const newLatLng = leafletMethods.latLng(newVal);
         if (
           newLatLng.lat !== oldLatLng.lat ||
           newLatLng.lng !== oldLatLng.lng
         ) {
-          mapRef.value.setLatLng(newLatLng);
+          leafletRef.value.setLatLng(newLatLng);
         }
       }
     },

--- a/src/functions/popper.js
+++ b/src/functions/popper.js
@@ -5,12 +5,12 @@ export const props = {
   },
 };
 
-export const setup = (props, mapRef) => {
+export const setup = (props, leafletRef) => {
   const options = {};
   const methods = {
     setContent(newVal) {
-      if (mapRef.value && newVal !== null && newVal !== undefined) {
-        mapRef.value.setContent(newVal);
+      if (leafletRef.value && newVal !== null && newVal !== undefined) {
+        leafletRef.value.setContent(newVal);
       }
     },
   };

--- a/src/functions/tileLayer.js
+++ b/src/functions/tileLayer.js
@@ -20,11 +20,11 @@ export const props = {
   },
 };
 
-export const setup = (props, mapRef) => {
+export const setup = (props, leafletRef) => {
   const {
     options: gridLayerOptions,
     methods: gridLayerMethods,
-  } = gridLayerSetup(props, mapRef);
+  } = gridLayerSetup(props, leafletRef);
   const options = {
     ...gridLayerOptions,
     tms: props.tms,

--- a/src/functions/tooltip.js
+++ b/src/functions/tooltip.js
@@ -5,8 +5,8 @@ export const props = {
   ...popperProps,
 };
 
-export const setup = (props, mapRef, context, lMethods) => {
-  const { options, methods } = popperSetup(props, mapRef);
+export const setup = (props, leafletRef, context, lMethods) => {
+  const { options, methods } = popperSetup(props, leafletRef);
 
   onBeforeUnmount(() => {
     lMethods.unbindTooltip();


### PR DESCRIPTION
As discussed in #23, the terminology "mapRef" and "mapObject" to refer to references and objects that are _not_ maps has caused some confusion in the past. This replaces all instances of them with the hopefully more appropriate "leaflet"-based equivalents.