### PR TITLE
Leaflet provide/inject wrapper

### DIFF
--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -1,7 +1,7 @@
 <script>
-import { onMounted, ref, inject } from "vue";
+import { onMounted, ref } from "vue";
 import { props, setup as controlSetup } from "../functions/controlLayers";
-import { propsBinder } from "../utils.js";
+import { injectLeafletMethod, propsBinder } from "../utils.js";
 
 export default {
   name: "LControlLayers",
@@ -9,7 +9,7 @@ export default {
   setup(props) {
     const leafletRef = ref({});
 
-    const lMethods = inject("leafLetMethods");
+    const registerLayerControl = injectLeafletMethod("registerLayerControl");
     const { options, methods } = controlSetup(props, leafletRef);
     onMounted(async () => {
       const { control, setOptions } = await import(
@@ -19,7 +19,7 @@ export default {
       leafletRef.value = control.layers(null, null, options);
       propsBinder(methods, leafletRef.value, props, setOptions);
 
-      lMethods.registerLayerControl({
+      registerLayerControl({
         ...props,
         ...methods,
         leafletObject: leafletRef.value,

--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -1,7 +1,7 @@
 <script>
-import { onMounted, ref } from "vue";
+import { onMounted, ref, inject } from "vue";
 import { props, setup as controlSetup } from "../functions/controlLayers";
-import { injectLeafletMethod, propsBinder } from "../utils.js";
+import { propsBinder } from "../utils.js";
 
 export default {
   name: "LControlLayers",
@@ -9,7 +9,7 @@ export default {
   setup(props) {
     const leafletRef = ref({});
 
-    const registerLayerControl = injectLeafletMethod("registerLayerControl");
+    const registerLayerControl = inject("registerLayerControl");
     const { options, methods } = controlSetup(props, leafletRef);
     onMounted(async () => {
       const { control, setOptions } = await import(

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -11,8 +11,8 @@ import {
   propsBinder,
   debounce,
   resetWebpackIcon,
-  updateLeafletMethod,
   provideLeafletPlaceholders,
+  updateLeafletMethods,
 } from "../utils.js";
 
 export default {
@@ -327,12 +327,7 @@ export default {
         },
       };
 
-      updateLeafletMethod(schematics.addLayer, methods.addLayer);
-      updateLeafletMethod(schematics.removeLayer, methods.removeLayer);
-      updateLeafletMethod(
-        schematics.registerLayerControl,
-        methods.registerLayerControl
-      );
+      updateLeafletMethods(schematics, methods);
 
       blueprint.leafletRef = map(root.value, options);
 

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -5,20 +5,15 @@
 </template>
 
 <script>
-import {
-  onMounted,
-  onBeforeUnmount,
-  computed,
-  provide,
-  reactive,
-  ref,
-} from "vue";
+import { onMounted, onBeforeUnmount, computed, reactive, ref } from "vue";
 import {
   remapEvents,
   propsBinder,
   debounce,
   resetWebpackIcon,
   generatePlaceholderMethods,
+  provideLeafletMethods,
+  updateLeafletMethod,
 } from "../utils.js";
 
 export default {
@@ -175,7 +170,8 @@ export default {
       "registerLayerControl",
     ]);
 
-    provide("leafLetMethods", schematics);
+    console.log("Providing placeholder addLayer");
+    provideLeafletMethods(schematics);
 
     const eventHandlers = {
       moveEndHandler() {
@@ -335,9 +331,13 @@ export default {
         },
       };
 
-      schematics.addLayer = methods.addLayer;
-      schematics.removeLayer = methods.removeLayer;
-      schematics.registerLayerControl = methods.registerLayerControl;
+      console.log("Reassigning addLayer");
+      updateLeafletMethod(schematics.addLayer, methods.addLayer);
+      updateLeafletMethod(schematics.removeLayer, methods.removeLayer);
+      updateLeafletMethod(
+        schematics.registerLayerControl,
+        methods.registerLayerControl
+      );
 
       blueprint.leafletRef = map(root.value, options);
 

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -5,7 +5,14 @@
 </template>
 
 <script>
-import { onMounted, onBeforeUnmount, computed, reactive, ref } from "vue";
+import {
+  onMounted,
+  onBeforeUnmount,
+  computed,
+  reactive,
+  ref,
+  provide,
+} from "vue";
 import {
   remapEvents,
   propsBinder,
@@ -164,10 +171,15 @@ export default {
     };
 
     const schematics = provideLeafletPlaceholders([
-      "addLayer",
       "removeLayer",
       "registerLayerControl",
     ]);
+
+    const addLayerWrapper = ref(() =>
+      console.log("addLayer is not defined yet")
+    );
+    const addLayer = (...args) => addLayerWrapper.value(...args);
+    provide("addLayer", addLayer);
 
     const eventHandlers = {
       moveEndHandler() {
@@ -328,6 +340,7 @@ export default {
       };
 
       updateLeafletMethods(schematics, methods);
+      addLayerWrapper.value = methods.addLayer;
 
       blueprint.leafletRef = map(root.value, options);
 

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -11,9 +11,8 @@ import {
   propsBinder,
   debounce,
   resetWebpackIcon,
-  generatePlaceholderMethods,
-  provideLeafletMethods,
   updateLeafletMethod,
+  provideLeafletPlaceholders,
 } from "../utils.js";
 
 export default {
@@ -164,14 +163,11 @@ export default {
       markerZoomAnimation: props.markerZoomAnimation,
     };
 
-    const schematics = generatePlaceholderMethods([
+    const schematics = provideLeafletPlaceholders([
       "addLayer",
       "removeLayer",
       "registerLayerControl",
     ]);
-
-    console.log("Providing placeholder addLayer");
-    provideLeafletMethods(schematics);
 
     const eventHandlers = {
       moveEndHandler() {
@@ -331,7 +327,6 @@ export default {
         },
       };
 
-      console.log("Reassigning addLayer");
       updateLeafletMethod(schematics.addLayer, methods.addLayer);
       updateLeafletMethod(schematics.removeLayer, methods.removeLayer);
       updateLeafletMethod(

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -5,21 +5,14 @@
 </template>
 
 <script>
-import {
-  onMounted,
-  onBeforeUnmount,
-  computed,
-  reactive,
-  ref,
-  provide,
-} from "vue";
+import { onMounted, onBeforeUnmount, computed, reactive, ref } from "vue";
 import {
   remapEvents,
   propsBinder,
   debounce,
   resetWebpackIcon,
-  provideLeafletPlaceholders,
-  updateLeafletMethods,
+  provideLeafletWrapper,
+  updateLeafletWrapper,
 } from "../utils.js";
 
 export default {
@@ -170,16 +163,9 @@ export default {
       markerZoomAnimation: props.markerZoomAnimation,
     };
 
-    const schematics = provideLeafletPlaceholders([
-      "removeLayer",
-      "registerLayerControl",
-    ]);
-
-    const addLayerWrapper = ref(() =>
-      console.log("addLayer is not defined yet")
-    );
-    const addLayer = (...args) => addLayerWrapper.value(...args);
-    provide("addLayer", addLayer);
+    const addLayer = provideLeafletWrapper("addLayer");
+    const removeLayer = provideLeafletWrapper("removeLayer");
+    const registerLayerControl = provideLeafletWrapper("registerLayerControl");
 
     const eventHandlers = {
       moveEndHandler() {
@@ -339,8 +325,9 @@ export default {
         },
       };
 
-      updateLeafletMethods(schematics, methods);
-      addLayerWrapper.value = methods.addLayer;
+      updateLeafletWrapper(addLayer, methods.addLayer);
+      updateLeafletWrapper(removeLayer, methods.removeLayer);
+      updateLeafletWrapper(registerLayerControl, methods.registerLayerControl);
 
       blueprint.leafletRef = map(root.value, options);
 

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -4,8 +4,8 @@ import {
   remapEvents,
   propsBinder,
   debounce,
-  provideLeafletPlaceholders,
-  updateLeafletMethods,
+  provideLeafletWrapper,
+  updateLeafletWrapper,
 } from "../utils.js";
 import { props, setup as markerSetup } from "../functions/marker";
 
@@ -19,21 +19,19 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
-    const schematics = provideLeafletPlaceholders(["latLng"]);
-
     const addLayer = inject("addLayer");
-    const { options, methods } = markerSetup(
-      props,
-      leafletRef,
-      context,
-      schematics
-    );
+
+    const latLng = provideLeafletWrapper("latLng");
+    const { options, methods } = markerSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { marker, DomEvent, latLng, setOptions } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
-      updateLeafletMethods(schematics, { latLng });
+      const {
+        marker,
+        DomEvent,
+        latLng: leafletLatLng,
+        setOptions,
+      } = await import("leaflet/dist/leaflet-src.esm");
+      updateLeafletWrapper(latLng, leafletLatLng);
 
       leafletRef.value = marker(props.latLng, options);
 

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -1,10 +1,12 @@
 <script>
-import { onMounted, ref, inject, h } from "vue";
+import { onMounted, ref, h } from "vue";
 import {
   remapEvents,
   propsBinder,
   debounce,
   generatePlaceholderMethods,
+  injectLeafletMethod,
+  updateLeafletMethod,
 } from "../utils.js";
 import { props, setup as markerSetup } from "../functions/marker";
 
@@ -20,7 +22,8 @@ export default {
 
     const schematics = generatePlaceholderMethods(["latLng"]);
 
-    const lMethods = inject("leafLetMethods");
+    console.log("Injecting addLayer to LMarker");
+    const addLayer = injectLeafletMethod("addLayer");
     const { options, methods } = markerSetup(
       props,
       leafletRef,
@@ -32,7 +35,7 @@ export default {
       const { marker, DomEvent, latLng, setOptions } = await import(
         "leaflet/dist/leaflet-src.esm"
       );
-      schematics.latLng = latLng;
+      updateLeafletMethod(schematics.latLng, latLng);
 
       leafletRef.value = marker(props.latLng, options);
 
@@ -41,7 +44,7 @@ export default {
 
       leafletRef.value.on("move", debounce(methods.latLngSync, 100));
       propsBinder(methods, leafletRef.value, props, setOptions);
-      lMethods.addLayer({
+      addLayer({
         ...props,
         ...methods,
         leafletObject: leafletRef.value,

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -1,11 +1,10 @@
 <script>
-import { onMounted, ref, h } from "vue";
+import { onMounted, ref, h, inject } from "vue";
 import {
   remapEvents,
   propsBinder,
   debounce,
   provideLeafletPlaceholders,
-  injectLeafletMethod,
   updateLeafletMethods,
 } from "../utils.js";
 import { props, setup as markerSetup } from "../functions/marker";
@@ -22,7 +21,7 @@ export default {
 
     const schematics = provideLeafletPlaceholders(["latLng"]);
 
-    const addLayer = injectLeafletMethod("addLayer");
+    const addLayer = inject("addLayer");
     const { options, methods } = markerSetup(
       props,
       leafletRef,

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -6,7 +6,7 @@ import {
   debounce,
   provideLeafletPlaceholders,
   injectLeafletMethod,
-  updateLeafletMethod,
+  updateLeafletMethods,
 } from "../utils.js";
 import { props, setup as markerSetup } from "../functions/marker";
 
@@ -34,7 +34,7 @@ export default {
       const { marker, DomEvent, latLng, setOptions } = await import(
         "leaflet/dist/leaflet-src.esm"
       );
-      updateLeafletMethod(schematics.latLng, latLng);
+      updateLeafletMethods(schematics, { latLng });
 
       leafletRef.value = marker(props.latLng, options);
 

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -4,7 +4,7 @@ import {
   remapEvents,
   propsBinder,
   debounce,
-  generatePlaceholderMethods,
+  provideLeafletPlaceholders,
   injectLeafletMethod,
   updateLeafletMethod,
 } from "../utils.js";
@@ -20,9 +20,8 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
-    const schematics = generatePlaceholderMethods(["latLng"]);
+    const schematics = provideLeafletPlaceholders(["latLng"]);
 
-    console.log("Injecting addLayer to LMarker");
     const addLayer = injectLeafletMethod("addLayer");
     const { options, methods } = markerSetup(
       props,

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -1,13 +1,14 @@
 <script>
-import { onMounted, ref, inject } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import { onMounted, ref } from "vue";
+import { remapEvents, propsBinder, injectLeafletMethod } from "../utils.js";
 import { props, setup as tileLayerSetup } from "../functions/tileLayer";
 
 export default {
   props,
   setup(props, context) {
     const leafletRef = ref({});
-    const lMethods = inject("leafLetMethods");
+    console.log("injecting addLayer to LTileLayer");
+    const addLayer = injectLeafletMethod("addLayer");
 
     const { options, methods } = tileLayerSetup(props, leafletRef);
 
@@ -21,7 +22,7 @@ export default {
       DomEvent.on(leafletRef.value, listeners);
 
       propsBinder(methods, leafletRef.value, props, setOptions);
-      lMethods.addLayer({
+      addLayer({
         ...props,
         ...methods,
         leafletObject: leafletRef.value,

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -7,7 +7,6 @@ export default {
   props,
   setup(props, context) {
     const leafletRef = ref({});
-    console.log("injecting addLayer to LTileLayer");
     const addLayer = injectLeafletMethod("addLayer");
 
     const { options, methods } = tileLayerSetup(props, leafletRef);

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -7,6 +7,7 @@ export default {
   props,
   setup(props, context) {
     const leafletRef = ref({});
+    //const addLayer = injectLeafletMethod("addLayer");
     const addLayer = inject("addLayer");
 
     const { options, methods } = tileLayerSetup(props, leafletRef);

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -1,13 +1,13 @@
 <script>
-import { onMounted, ref } from "vue";
-import { remapEvents, propsBinder, injectLeafletMethod } from "../utils.js";
+import { onMounted, ref, inject } from "vue";
+import { remapEvents, propsBinder } from "../utils.js";
 import { props, setup as tileLayerSetup } from "../functions/tileLayer";
 
 export default {
   props,
   setup(props, context) {
     const leafletRef = ref({});
-    const addLayer = injectLeafletMethod("addLayer");
+    const addLayer = inject("addLayer");
 
     const { options, methods } = tileLayerSetup(props, leafletRef);
 

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -1,6 +1,6 @@
 <script>
-import { onMounted, ref, inject, h } from "vue";
-import { propsBinder, remapEvents } from "../utils.js";
+import { onMounted, ref, h } from "vue";
+import { injectLeafletMethod, propsBinder, remapEvents } from "../utils.js";
 import { setup as tooltipSetup, props } from "../functions/tooltip";
 
 /**
@@ -13,13 +13,8 @@ export default {
     const leafletRef = ref({});
     const root = ref(null);
 
-    const lMethods = inject("leafLetMethods");
-    const { options, methods } = tooltipSetup(
-      props,
-      leafletRef,
-      context,
-      lMethods
-    );
+    const bindTooltip = injectLeafletMethod("bindTooltip");
+    const { options, methods } = tooltipSetup(props, leafletRef, context);
 
     onMounted(async () => {
       const { tooltip, DomEvent, setOptions } = await import(
@@ -32,7 +27,7 @@ export default {
       const listeners = remapEvents(context.attrs);
       DomEvent.on(leafletRef.value, listeners);
       leafletRef.value.setContent(props.content || root.value);
-      lMethods.bindTooltip({ leafletObject: leafletRef.value });
+      bindTooltip({ leafletObject: leafletRef.value });
     });
     return { root };
   },

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -1,6 +1,6 @@
 <script>
-import { onMounted, ref, h } from "vue";
-import { injectLeafletMethod, propsBinder, remapEvents } from "../utils.js";
+import { onMounted, ref, h, inject } from "vue";
+import { propsBinder, remapEvents } from "../utils.js";
 import { setup as tooltipSetup, props } from "../functions/tooltip";
 
 /**
@@ -13,7 +13,7 @@ export default {
     const leafletRef = ref({});
     const root = ref(null);
 
-    const bindTooltip = injectLeafletMethod("bindTooltip");
+    const bindTooltip = inject("bindTooltip");
     const { options, methods } = tooltipSetup(props, leafletRef, context);
 
     onMounted(async () => {

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -1,9 +1,4 @@
-import { onUnmounted } from "vue";
-import {
-  provideLeafletPlaceholders,
-  injectLeafletMethod,
-  updateLeafletMethods,
-} from "../utils";
+import { onUnmounted, provide, inject } from "vue";
 
 export const props = {
   pane: {
@@ -32,8 +27,8 @@ export const props = {
 };
 
 export const setup = (props, leafletRef, context) => {
-  const addLayer = injectLeafletMethod("addLayer");
-  const removeLayer = injectLeafletMethod("removeLayer");
+  const addLayer = inject("addLayer");
+  const removeLayer = inject("removeLayer");
   const options = {
     attribution: props.attribution,
     pane: props.pane,
@@ -90,11 +85,8 @@ export const setup = (props, leafletRef, context) => {
     },
   };
 
-  const schematics = provideLeafletPlaceholders([
-    "bindTooltip",
-    "unbindTooltip",
-  ]);
-  updateLeafletMethods(schematics, methods);
+  provide("bindTooltip", methods.bindTooltip);
+  provide("unbindTooltip", methods.unbindTooltip);
 
   onUnmounted(() => {
     methods.unbindPopup();

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -2,7 +2,7 @@ import { onUnmounted } from "vue";
 import {
   provideLeafletPlaceholders,
   injectLeafletMethod,
-  updateLeafletMethod,
+  updateLeafletMethods,
 } from "../utils";
 
 export const props = {
@@ -94,8 +94,7 @@ export const setup = (props, leafletRef, context) => {
     "bindTooltip",
     "unbindTooltip",
   ]);
-  updateLeafletMethod(schematics.bindTooltip, methods.bindTooltip);
-  updateLeafletMethod(schematics.unbindTooltip, methods.unbindTooltip);
+  updateLeafletMethods(schematics, methods);
 
   onUnmounted(() => {
     methods.unbindPopup();

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -1,5 +1,9 @@
-import { onUnmounted, provide } from "vue";
-import { injectLeafletMethod } from "../utils";
+import { onUnmounted } from "vue";
+import {
+  provideLeafletPlaceholders,
+  injectLeafletMethod,
+  updateLeafletMethod,
+} from "../utils";
 
 export const props = {
   pane: {
@@ -28,7 +32,6 @@ export const props = {
 };
 
 export const setup = (props, leafletRef, context) => {
-  console.log("injecting addLayer to layer");
   const addLayer = injectLeafletMethod("addLayer");
   const removeLayer = injectLeafletMethod("removeLayer");
   const options = {
@@ -87,8 +90,12 @@ export const setup = (props, leafletRef, context) => {
     },
   };
 
-  provide("bindTooltip", methods.bindTooltip);
-  provide("unbindTooltip", methods.unbindTooltip);
+  const schematics = provideLeafletPlaceholders([
+    "bindTooltip",
+    "unbindTooltip",
+  ]);
+  updateLeafletMethod(schematics.bindTooltip, methods.bindTooltip);
+  updateLeafletMethod(schematics.unbindTooltip, methods.unbindTooltip);
 
   onUnmounted(() => {
     methods.unbindPopup();

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -1,4 +1,5 @@
-import { inject, onUnmounted, provide } from "vue";
+import { onUnmounted, provide } from "vue";
+import { injectLeafletMethod } from "../utils";
 
 export const props = {
   pane: {
@@ -27,7 +28,9 @@ export const props = {
 };
 
 export const setup = (props, leafletRef, context) => {
-  const lMethods = inject("leafLetMethods");
+  console.log("injecting addLayer to layer");
+  const addLayer = injectLeafletMethod("addLayer");
+  const removeLayer = injectLeafletMethod("removeLayer");
   const options = {
     attribution: props.attribution,
     pane: props.pane,
@@ -39,23 +42,23 @@ export const setup = (props, leafletRef, context) => {
       attributionControl.removeAttribution(old).addAttribution(val);
     },
     setName() {
-      lMethods.removeLayer(leafletRef.value);
+      removeLayer(leafletRef.value);
       if (props.visible) {
-        lMethods.addLayer(leafletRef.value);
+        addLayer(leafletRef.value);
       }
     },
     setLayerType() {
-      lMethods.removeLayer(leafletRef.value);
+      removeLayer(leafletRef.value);
       if (props.visible) {
-        lMethods.addLayer(leafletRef.value);
+        addLayer(leafletRef.value);
       }
     },
     setVisible(isVisible) {
       if (leafletRef.value) {
         if (isVisible) {
-          lMethods.addLayer(leafletRef.value);
+          addLayer(leafletRef.value);
         } else {
-          lMethods.removeLayer(leafletRef.value);
+          removeLayer(leafletRef.value);
         }
       }
     },
@@ -84,16 +87,13 @@ export const setup = (props, leafletRef, context) => {
     },
   };
 
-  provide("leafLetMethods", {
-    ...lMethods,
-    bindTooltip: methods.bindTooltip,
-    unbindTooltip: methods.unbindTooltip,
-  });
+  provide("bindTooltip", methods.bindTooltip);
+  provide("unbindTooltip", methods.unbindTooltip);
 
   onUnmounted(() => {
     methods.unbindPopup();
     methods.unbindTooltip();
-    lMethods.removeLayer({ leafletObject: leafletRef.value });
+    removeLayer({ leafletObject: leafletRef.value });
   });
 
   return { options, methods };

--- a/src/functions/marker.js
+++ b/src/functions/marker.js
@@ -1,5 +1,5 @@
+import { inject } from "vue";
 import { props as layerProps, setup as layerSetup } from "../functions/layer";
-import { injectLeafletMethod } from "../utils";
 
 export const props = {
   ...layerProps,
@@ -38,7 +38,7 @@ export const setup = (props, leafletRef, context) => {
     ...layerOptions,
     ...props,
   };
-  const latLng = injectLeafletMethod("latLng");
+  const latLng = inject("latLng");
 
   const methods = {
     ...layerMethods,

--- a/src/functions/marker.js
+++ b/src/functions/marker.js
@@ -1,4 +1,5 @@
 import { props as layerProps, setup as layerSetup } from "../functions/layer";
+import { injectLeafletMethod } from "../utils";
 
 export const props = {
   ...layerProps,
@@ -27,7 +28,7 @@ export const props = {
   },
 };
 
-export const setup = (props, leafletRef, context, leafletMethods) => {
+export const setup = (props, leafletRef, context) => {
   const { options: layerOptions, methods: layerMethods } = layerSetup(
     props,
     leafletRef,
@@ -37,6 +38,7 @@ export const setup = (props, leafletRef, context, leafletMethods) => {
     ...layerOptions,
     ...props,
   };
+  const latLng = injectLeafletMethod("latLng");
 
   const methods = {
     ...layerMethods,
@@ -58,7 +60,7 @@ export const setup = (props, leafletRef, context, leafletMethods) => {
 
       if (leafletRef.value) {
         const oldLatLng = leafletRef.value.getLatLng();
-        const newLatLng = leafletMethods.latLng(newVal);
+        const newLatLng = latLng(newVal);
         if (
           newLatLng.lat !== oldLatLng.lat ||
           newLatLng.lng !== oldLatLng.lng

--- a/src/functions/tooltip.js
+++ b/src/functions/tooltip.js
@@ -1,5 +1,4 @@
-import { onBeforeUnmount } from "vue";
-import { injectLeafletMethod } from "../utils";
+import { onBeforeUnmount, inject } from "vue";
 import { props as popperProps, setup as popperSetup } from "./popper";
 
 export const props = {
@@ -8,7 +7,7 @@ export const props = {
 
 export const setup = (props, leafletRef) => {
   const { options, methods } = popperSetup(props, leafletRef);
-  const unbindTooltip = injectLeafletMethod("unbindTooltip");
+  const unbindTooltip = inject("unbindTooltip");
 
   onBeforeUnmount(() => {
     unbindTooltip();

--- a/src/functions/tooltip.js
+++ b/src/functions/tooltip.js
@@ -1,15 +1,17 @@
 import { onBeforeUnmount } from "vue";
+import { injectLeafletMethod } from "../utils";
 import { props as popperProps, setup as popperSetup } from "./popper";
 
 export const props = {
   ...popperProps,
 };
 
-export const setup = (props, leafletRef, context, lMethods) => {
+export const setup = (props, leafletRef) => {
   const { options, methods } = popperSetup(props, leafletRef);
+  const unbindTooltip = injectLeafletMethod("unbindTooltip");
 
   onBeforeUnmount(() => {
-    lMethods.unbindTooltip();
+    unbindTooltip();
   });
 
   return { options, methods };

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,19 +71,21 @@ export const resetWebpackIcon = (Icon) => {
   });
 };
 
-export const generatePlaceholderMethods = (methods) => {
-  const base = {}; //reactive({});
-  return methods.reduce((acc, curr) => {
-    acc[curr] = ref(() =>
-      console.warn(`Method ${curr} has been invoked without being replaced`)
+export const provideLeafletPlaceholders = (methodNames) => {
+  return methodNames.reduce((methods, methodName) => {
+    methods[methodName] = ref(() =>
+      console.warn(
+        `Method ${methodName} has been invoked without being replaced`
+      )
     );
-    return acc;
-  }, base);
+    provide(methodName, methods[methodName]);
+    return methods;
+  }, {});
 };
 
-export const provideLeafletMethods = (obj) => {
-  for (const key in obj) {
-    provide(key, obj[key]);
+export const provideLeafletMethods = (methods) => {
+  for (const methodName in methods) {
+    provide(methodName, methods[methodName]);
   }
 };
 
@@ -93,7 +95,6 @@ export const updateLeafletMethod = (methodRef, updateMethod) => {
 
 export const injectLeafletMethod = (methodName) => {
   const method = inject(methodName);
-  console.log("injected method", method);
   return (
     (method && method.value) ||
     (() => console.warn(`"${methodName}" not provided as Leaflet method.`))

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,17 +71,31 @@ export const resetWebpackIcon = (Icon) => {
   });
 };
 
+/**
+ * Wraps a placeholder function and provides it with the given name.
+ * The wrapper can later be updated with {@link updateLeafletWrapper}
+ * to provide a different function.
+ *
+ * @param {String} methodName Key used to provide the wrapper function
+ */
 export const provideLeafletWrapper = (methodName) => {
-  const wrapper = ref(() =>
+  const wrapped = ref(() =>
     console.warn(`Method ${methodName} has been invoked without being replaced`)
   );
-  const wrapped = (...args) => wrapper.value(...args);
+  const wrapper = (...args) => wrapped.value(...args);
   // eslint-disable-next-line vue/no-ref-as-operand
-  wrapped.wrapper = wrapper;
-  provide(methodName, wrapped);
+  wrapper.wrapped = wrapped;
+  provide(methodName, wrapper);
 
-  return wrapped;
+  return wrapper;
 };
 
-export const updateLeafletWrapper = (wrapped, leafletMethod) =>
-  (wrapped.wrapper.value = leafletMethod);
+/**
+ * Change the function that will be executed when an injected Leaflet wrapper
+ * is invoked.
+ *
+ * @param {*} wrapper Provided wrapper whose wrapped function is to be updated
+ * @param {function} leafletMethod New method to be wrapped by the wrapper
+ */
+export const updateLeafletWrapper = (wrapper, leafletMethod) =>
+  (wrapper.wrapped.value = leafletMethod);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { watch, ref, provide, inject } from "vue";
+import { watch, ref, provide } from "vue";
 
 export const debounce = (fn, time) => {
   let timeout;
@@ -71,47 +71,17 @@ export const resetWebpackIcon = (Icon) => {
   });
 };
 
-export const provideLeafletPlaceholders = (methodNames) => {
-  return methodNames.reduce((methods, methodName) => {
-    methods[methodName] = ref(() =>
-      console.warn(
-        `Method ${methodName} has been invoked without being replaced`
-      )
-    );
-    provide(methodName, methods[methodName]);
-    return methods;
-  }, {});
-};
-
-export const provideLeafletMethods = (methods) => {
-  for (const methodName in methods) {
-    provide(methodName, methods[methodName]);
-  }
-};
-
-/**
- * Update any or all of the leaflet method references originally created
- * by provideLeafletMethods.
- *
- * Each key that exists in the updateMethods object will replace the Leaflet
- * method with the same name in methodRefs, if it exists. Methods that are
- * not already part of methodRefs will not be added.
- *
- * @param {*} methodRefs
- * @param {*} updateMethods
- */
-export const updateLeafletMethods = (methodRefs, updateMethods) => {
-  for (const methodName in updateMethods) {
-    if (methodRefs[methodName]) {
-      methodRefs[methodName].value = updateMethods[methodName];
-    }
-  }
-};
-
-export const injectLeafletMethod = (methodName) => {
-  const method = inject(methodName);
-  return (
-    (method && method.value) ||
-    (() => console.warn(`"${methodName}" not provided as Leaflet method.`))
+export const provideLeafletWrapper = (methodName) => {
+  const wrapper = ref(() =>
+    console.warn(`Method ${methodName} has been invoked without being replaced`)
   );
+  const wrapped = (...args) => wrapper.value(...args);
+  // eslint-disable-next-line vue/no-ref-as-operand
+  wrapped.wrapper = wrapper;
+  provide(methodName, wrapped);
+
+  return wrapped;
 };
+
+export const updateLeafletWrapper = (wrapped, leafletMethod) =>
+  (wrapped.wrapper.value = leafletMethod);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { watch, reactive } from "vue";
+import { watch, ref, provide, inject } from "vue";
 
 export const debounce = (fn, time) => {
   let timeout;
@@ -72,10 +72,30 @@ export const resetWebpackIcon = (Icon) => {
 };
 
 export const generatePlaceholderMethods = (methods) => {
-  const base = reactive({});
+  const base = {}; //reactive({});
   return methods.reduce((acc, curr) => {
-    acc[curr] = () =>
-      console.warn(`Method ${curr} has been invoked without being replaced`);
+    acc[curr] = ref(() =>
+      console.warn(`Method ${curr} has been invoked without being replaced`)
+    );
     return acc;
   }, base);
+};
+
+export const provideLeafletMethods = (obj) => {
+  for (const key in obj) {
+    provide(key, obj[key]);
+  }
+};
+
+export const updateLeafletMethod = (methodRef, updateMethod) => {
+  methodRef.value = updateMethod;
+};
+
+export const injectLeafletMethod = (methodName) => {
+  const method = inject(methodName);
+  console.log("injected method", method);
+  return (
+    (method && method.value) ||
+    (() => console.warn(`"${methodName}" not provided as Leaflet method.`))
+  );
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,8 +89,23 @@ export const provideLeafletMethods = (methods) => {
   }
 };
 
-export const updateLeafletMethod = (methodRef, updateMethod) => {
-  methodRef.value = updateMethod;
+/**
+ * Update any or all of the leaflet method references originally created
+ * by provideLeafletMethods.
+ *
+ * Each key that exists in the updateMethods object will replace the Leaflet
+ * method with the same name in methodRefs, if it exists. Methods that are
+ * not already part of methodRefs will not be added.
+ *
+ * @param {*} methodRefs
+ * @param {*} updateMethods
+ */
+export const updateLeafletMethods = (methodRefs, updateMethods) => {
+  for (const methodName in updateMethods) {
+    if (methodRefs[methodName]) {
+      methodRefs[methodName].value = updateMethods[methodName];
+    }
+  }
 };
 
 export const injectLeafletMethod = (methodName) => {


### PR DESCRIPTION
@DonNicoJs I started working on the `LIcon` component, but ended up running into troubles around the current setup for overriding provided methods. Maybe I am just missing something obvious (or subtle!) but I think that there is a real problem with the approach of providing a single `leafletMethods` object, and replacing some of its methods and re-providing them elsewhere, since in the end it is really a single globally provided object.

For example, if `LMap` provides and `addLayer` method in the `leafletMethods` object, and then `LLayerGroup` overwrites that, all layers that inject `addLayer` after the layer group has mounted will be added to the group instead of the map, even if they are outside of that group in the template. Here is an example of this in action, with fake simulated mapping components: https://codesandbox.io/s/vl-provide-methods-object-6e5ze?file=/src/App.vue

You can easily see that even though the final fake tile layer lives within the map but outside the layer group, it appears inside the group anyway. This is because when the layer group gets created, it replaces `allMethods.addLayer`, which changes the underlying object that is still provided by the map. Here's a version that is almost identical, except that `addLayer` is provided and injected directly as a function, so when the layer group overrides it for its children, that doesn't update the one provided by its parent: https://codesandbox.io/s/vl-provide-individual-methods-37d1m?file=/src/App.vue

This PR attempts to solve this issue, preserve the ability to lazy load Leaflet methods for SSR compatibility, and not require every method to be called with `.value`.

The key elements are the new `provideLeafletWrapper` and `updateLeafletWrapper` functions. The first is called in `setup` as early as we want, and creates a function that can be invoked directly, and that has also been `provide`d already. The returned function however also has a `.wrapped` property, that is a `ref` to a placeholder function. The second function, `updateLeafletWrapper`, simply updates the value of the ref that is wrapped.

To use it we would do, for example:

1. Call `const addLayer = provideLeafletWrapper("addLayer")` in the `setup` of `LMap`
2. In the async `onMounted` callback:
  a. Dynamically import Leaflet methods,
  b. Define a method to add a layer to this specific map, say `addMapLayer`,
  c. Call `updateLeafletWrapper(addLayer, addMapLayer)`
3. In any other component that needs access to an `addLayer` function, simply use
  `const addLayer = inject("addLayer");`
  `addLayer(layer);`

---

Looking forward to seeing what you think! Is there a reason the issue I point out above doesn't actually exist or can be easily avoided within the current approach? Does this new approach introduce any additional problems I haven't thought of?