### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "main": "dist/vue-leaflet.cjs.js",
   "unpkg": "dist/vue-leaflet.umd.js",
-  "module": "dist/vue-leaflet.es.js",
+  "module": "dist/vue-leaflet.esm.js",
   "files": [
     "dist/",
     "src/"


### PR DESCRIPTION
rollup generates `vue-leaflet.esm.js` and not `vue-leaflet.es.js`
