### PR TITLE
Replace node require by browser import

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,7 @@
 import { watch, reactive } from "vue";
+import iconRetinaUrl from "leaflet/dist/images/marker-icon-2x.png"
+import iconUrl from "leaflet/dist/images/marker-icon.png"
+import shadowUrl from "leaflet/dist/images/marker-shadow.png"
 
 export const debounce = (fn, time) => {
   let timeout;
@@ -65,9 +68,9 @@ export const resetWebpackIcon = (Icon) => {
   delete Icon.Default.prototype._getIconUrl;
 
   Icon.Default.mergeOptions({
-    iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),
-    iconUrl: require("leaflet/dist/images/marker-icon.png"),
-    shadowUrl: require("leaflet/dist/images/marker-shadow.png"),
+    iconRetinaUrl,
+    iconUrl,
+    shadowUrl,
   });
 };
 


### PR DESCRIPTION
Hi, 
When using require we can't use the es-module build, because the project need to be rebuilt by webpack.

(You can try the package in a viteJS project, and you'll see the fail)

Thanks.