### PR TITLE
Only include `on*` event handlers in attrs remap

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -50,12 +50,12 @@ export const propsBinder = (methods, leafletElement, props, setOptions) => {
   }
 };
 
-export const remapEvents = (onEvent) => {
+export const remapEvents = (contextAttrs) => {
   const result = {};
-  for (const eventName in onEvent) {
-    if (eventName !== "modelValue" && !eventName.startsWith("onUpdate")) {
-      const newName = eventName.replace("on", "").toLowerCase();
-      result[newName] = onEvent[eventName];
+  for (const attrName in contextAttrs) {
+    if (attrName.startsWith("on") && !attrName.startsWith("onUpdate")) {
+      const eventName = attrName.slice(2).toLocaleLowerCase();
+      result[eventName] = contextAttrs[attrName];
     }
   }
   return result;


### PR DESCRIPTION
If I understand its purpose correctly, the `remapEvents` function in `utils.js` should only return event handlers that have been renamed from e.g. `onClick` to `click`, as expected by Leaflet's `DomEvent.on`.

This PR makes that happen, excluding any other non-event-handler attributes from the returned object.

As before, the returned object still will not include an entry for `onUpdate` (or `modelValue`).