### PR TITLE
LIcon

### DIFF
--- a/src/Playground.vue
+++ b/src/Playground.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="height: 50vh; width: 50vw;">
+  <div style="height: 75vh; width: 50vw;">
     <l-map
       v-model="zoom"
       v-model:zoom="zoom"
@@ -15,11 +15,16 @@
           lol
         </l-tooltip>
       </l-marker>
+      <l-marker :lat-lng="[47.41322, -1.219482]">
+        <l-icon :icon-url="iconUrl" :icon-size="iconSize" />
+      </l-marker>
     </l-map>
+    <button @click="changeIcon">New kitten icon</button>
   </div>
 </template>
 <script>
 import LMap from "./components/LMap.vue";
+import LIcon from "./components/LIcon.vue";
 import LTileLayer from "./components/LTileLayer.vue";
 import LMarker from "./components/LMarker.vue";
 import LControlLayers from "./components/LControlLayers.vue";
@@ -28,6 +33,7 @@ import LTooltip from "./components/LTooltip.vue";
 export default {
   components: {
     LMap,
+    LIcon,
     LTileLayer,
     LMarker,
     LControlLayers,
@@ -36,11 +42,27 @@ export default {
   data() {
     return {
       zoom: 2,
+      iconWidth: 25,
+      iconHeight: 40,
     };
+  },
+  computed: {
+    iconUrl() {
+      return `https://placekitten.com/${this.iconWidth}/${this.iconHeight}`;
+    },
+    iconSize() {
+      return [this.iconWidth, this.iconHeight];
+    },
   },
   methods: {
     log(a) {
       console.log(a);
+    },
+    changeIcon() {
+      this.iconWidth += 2;
+      if (this.iconWidth > this.iconHeight) {
+        this.iconWidth = Math.floor(this.iconHeight / 2);
+      }
     },
   },
 };

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -1,7 +1,7 @@
 <script>
-import { onMounted, reactive, ref, inject } from "vue";
-import { props, setup as iconSetup } from "../functions/icon";
-import { generatePlaceholderMethods } from "../utils";
+import { onMounted, ref, inject, nextTick, h } from "vue";
+import { propsBinder, remapEvents } from "../utils";
+import { props } from "../functions/icon";
 
 /**
  * Icon component, lets you add and custom icons to the map
@@ -10,27 +10,96 @@ export default {
   name: "LIcon",
   props,
   setup(props, context) {
-    const leafletRef = ref({});
-    const schematics = generatePlaceholderMethods([
-      "DomEvent",
-      "divIcon",
-      "icon",
-    ]);
+    const root = ref(null);
 
-    const setIcon = inject("setIcon");
     const canSetParentHtml = inject("canSetParentHtml");
     const setParentHtml = inject("setParentHtml");
+    const setIcon = inject("setIcon");
+
+    let onDomEvent;
+    let offDomEvent;
+    let divIcon;
+    let icon;
+    let iconObject = undefined;
+
+    const createIcon = (el, recreationNeeded, htmlSwapNeeded) => {
+      const elHtml = el && el.innerHTML;
+      if (!recreationNeeded) {
+        if (htmlSwapNeeded && iconObject && canSetParentHtml()) {
+          setParentHtml(elHtml);
+        }
+        return;
+      }
+
+      const listeners = remapEvents(context.attrs);
+      if (iconObject) {
+        offDomEvent(iconObject, listeners);
+      }
+
+      const options = {
+        ...props,
+      };
+
+      if (elHtml) {
+        options.html = elHtml;
+      }
+
+      iconObject = options.html ? divIcon(options) : icon(options);
+      onDomEvent(iconObject, listeners);
+      setIcon(iconObject);
+    };
+
+    const scheduleCreateIcon = () => {
+      nextTick(() => createIcon(root.value, true, false));
+    };
+
+    const scheduleHtmlSwap = () => {
+      nextTick(() => createIcon(root.value, false, true));
+    };
+
+    const methods = {
+      setIconUrl: scheduleCreateIcon,
+      setIconRetinaUrl: scheduleCreateIcon,
+      setIconSize: scheduleCreateIcon,
+      setIconAnchor: scheduleCreateIcon,
+      setPopupAnchor: scheduleCreateIcon,
+      setTooltipAnchor: scheduleCreateIcon,
+      setShadowUrl: scheduleCreateIcon,
+      setShadowRetinaUrl: scheduleCreateIcon,
+      setShadowAnchor: scheduleCreateIcon,
+      setBgPos: scheduleCreateIcon,
+      setClassName: scheduleCreateIcon,
+      setHtml: scheduleCreateIcon,
+    };
 
     onMounted(async () => {
-      const { DomEvent, divIcon, icon } = await import(
+      const { DomEvent, divIcon: lDivIcon, icon: lIcon } = await import(
         "leaflet/dist/leaflet-src.esm"
       );
-      schematics.DomEvent = DomEvent;
-      schematics.divIcon = divIcon;
-      schematics.icon = icon;
 
-      leafletRef.value = 
+      onDomEvent = DomEvent.on;
+      offDomEvent = DomEvent.off;
+      divIcon = lDivIcon;
+      icon = lIcon;
+
+      propsBinder(methods, {}, props);
+
+      const observer = new MutationObserver(scheduleHtmlSwap);
+      observer.observe(root.value, {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+      scheduleCreateIcon();
     });
+
+    return { root };
+  },
+  render() {
+    const content = this.$slots.default ? this.$slots.default() : undefined;
+
+    return h("div", { ref: "root" }, content);
   },
 };
 </script>

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -1,6 +1,7 @@
 <script>
-import { onMounted, reactive, ref } from "vue";
+import { onMounted, reactive, ref, inject } from "vue";
 import { props, setup as iconSetup } from "../functions/icon";
+import { generatePlaceholderMethods } from "../utils";
 
 /**
  * Icon component, lets you add and custom icons to the map
@@ -10,11 +11,15 @@ export default {
   props,
   setup(props, context) {
     const leafletRef = ref({});
-    const schematics = reactive({
-      DomEvent: () => undefined,
-      divIcon: () => undefined,
-      icon: () => undefined,
-    });
+    const schematics = generatePlaceholderMethods([
+      "DomEvent",
+      "divIcon",
+      "icon",
+    ]);
+
+    const setIcon = inject("setIcon");
+    const canSetParentHtml = inject("canSetParentHtml");
+    const setParentHtml = inject("setParentHtml");
 
     onMounted(async () => {
       const { DomEvent, divIcon, icon } = await import(
@@ -23,6 +28,8 @@ export default {
       schematics.DomEvent = DomEvent;
       schematics.divIcon = divIcon;
       schematics.icon = icon;
+
+      leafletRef.value = 
     });
   },
 };

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -1,0 +1,29 @@
+<script>
+import { onMounted, reactive, ref } from "vue";
+import { props, setup as iconSetup } from "../functions/icon";
+
+/**
+ * Icon component, lets you add and custom icons to the map
+ */
+export default {
+  name: "LIcon",
+  props,
+  setup(props, context) {
+    const leafletRef = ref({});
+    const schematics = reactive({
+      DomEvent: () => undefined,
+      divIcon: () => undefined,
+      icon: () => undefined,
+    });
+
+    onMounted(async () => {
+      const { DomEvent, divIcon, icon } = await import(
+        "leaflet/dist/leaflet-src.esm"
+      );
+      schematics.DomEvent = DomEvent;
+      schematics.divIcon = divIcon;
+      schematics.icon = icon;
+    });
+  },
+};
+</script>

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -1,5 +1,5 @@
 <script>
-import { onMounted, ref, h, inject } from "vue";
+import { onMounted, ref, h, provide, inject } from "vue";
 import {
   remapEvents,
   propsBinder,
@@ -22,6 +22,15 @@ export default {
     const addLayer = inject("addLayer");
 
     const latLng = provideLeafletWrapper("latLng");
+    provide("canSetParentHtml", () => !!leafletRef.value.getElement());
+    provide(
+      "setParentHtml",
+      (html) => (leafletRef.value.getElement().innerHTML = html)
+    );
+    provide(
+      "setIcon",
+      (newIcon) => leafletRef.value.setIcon && leafletRef.value.setIcon(newIcon)
+    );
     const { options, methods } = markerSetup(props, leafletRef, context);
 
     onMounted(async () => {
@@ -34,10 +43,6 @@ export default {
       updateLeafletWrapper(latLng, leafletLatLng);
 
       leafletRef.value = marker(props.latLng, options);
-
-      schematics.canSetParentHtml = () => !!leafletRef.value.getElement();
-      schematics.setParentHtml = (html) =>
-        (leafletRef.value.getElement().innerHTML = html);
 
       const listeners = remapEvents(context.attrs);
       DomEvent.on(leafletRef.value, listeners);

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -35,6 +35,10 @@ export default {
 
       leafletRef.value = marker(props.latLng, options);
 
+      schematics.canSetParentHtml = () => !!leafletRef.value.getElement();
+      schematics.setParentHtml = (html) =>
+        (leafletRef.value.getElement().innerHTML = html);
+
       const listeners = remapEvents(context.attrs);
       DomEvent.on(leafletRef.value, listeners);
 

--- a/src/functions/icon.js
+++ b/src/functions/icon.js
@@ -1,5 +1,3 @@
-import { ref, nextTick } from "vue";
-
 export const props = {
   iconUrl: {
     type: String,
@@ -66,33 +64,4 @@ export const props = {
     custom: true,
     default: () => ({}),
   },
-};
-
-export const setup = (props, mapRef, context, leafletMethods) => {
-  let recreationNeeded = false;
-  let htmlSwapNeeded = false;
-  let iconObject = undefined;
-  const options = {
-    ...props,
-  };
-
-  const createIcon = () => {
-    if (htmlSwapNeeded && !recreationNeeded && iconObject)
-  };
-
-  const methods = {
-    scheduleCreateIcon() {
-      recreationNeeded.value = true;
-      nextTick(createIcon);
-    },
-
-    scheduleHtmlSwap() {
-      htmlSwapNeeded.value = true;
-      nextTick(createIcon);
-    },
-
-    createIcon,
-  };
-
-  return { options, methods };
 };

--- a/src/functions/icon.js
+++ b/src/functions/icon.js
@@ -69,10 +69,16 @@ export const props = {
 };
 
 export const setup = (props, mapRef, context, leafletMethods) => {
-  const recreationNeeded = ref(false);
-  const swapHtmlNeeded = ref(false);
+  let recreationNeeded = false;
+  let htmlSwapNeeded = false;
+  let iconObject = undefined;
+  const options = {
+    ...props,
+  };
 
-  const createIcon = () => {};
+  const createIcon = () => {
+    if (htmlSwapNeeded && !recreationNeeded && iconObject)
+  };
 
   const methods = {
     scheduleCreateIcon() {
@@ -81,12 +87,12 @@ export const setup = (props, mapRef, context, leafletMethods) => {
     },
 
     scheduleHtmlSwap() {
-      swapHtmlNeeded.value = true;
+      htmlSwapNeeded.value = true;
       nextTick(createIcon);
     },
 
     createIcon,
   };
 
-  return { methods };
+  return { options, methods };
 };

--- a/src/functions/icon.js
+++ b/src/functions/icon.js
@@ -1,0 +1,92 @@
+import { ref, nextTick } from "vue";
+
+export const props = {
+  iconUrl: {
+    type: String,
+    custom: true,
+    default: null,
+  },
+  iconRetinaUrl: {
+    type: String,
+    custom: true,
+    default: null,
+  },
+  iconSize: {
+    type: [Object, Array],
+    custom: true,
+    default: null,
+  },
+  iconAnchor: {
+    type: [Object, Array],
+    custom: true,
+    default: null,
+  },
+  popupAnchor: {
+    type: [Object, Array],
+    custom: true,
+    default: () => [0, 0],
+  },
+  tooltipAnchor: {
+    type: [Object, Array],
+    custom: true,
+    default: () => [0, 0],
+  },
+  shadowUrl: {
+    type: String,
+    custom: true,
+    default: null,
+  },
+  shadowRetinaUrl: {
+    type: String,
+    custom: true,
+    default: null,
+  },
+  shadowSize: {
+    type: [Object, Array],
+    custom: true,
+    default: null,
+  },
+  shadowAnchor: {
+    type: [Object, Array],
+    custom: true,
+    default: null,
+  },
+  bgPos: {
+    type: [Object, Array],
+    custom: true,
+    default: () => [0, 0],
+  },
+  className: {
+    type: String,
+    custom: true,
+    default: "",
+  },
+  options: {
+    type: Object,
+    custom: true,
+    default: () => ({}),
+  },
+};
+
+export const setup = (props, mapRef, context, leafletMethods) => {
+  const recreationNeeded = ref(false);
+  const swapHtmlNeeded = ref(false);
+
+  const createIcon = () => {};
+
+  const methods = {
+    scheduleCreateIcon() {
+      recreationNeeded.value = true;
+      nextTick(createIcon);
+    },
+
+    scheduleHtmlSwap() {
+      swapHtmlNeeded.value = true;
+      nextTick(createIcon);
+    },
+
+    createIcon,
+  };
+
+  return { methods };
+};


### PR DESCRIPTION
@DonNicoJs I have a largely working `LIcon` component here, at least good enough for early testing. The main outstanding issue with it is that almost all of the code—everything but `props` definition—is in the main SFC. I've been playing with a few approaches to make it more modular and extract more functionality to `icon.js`, but keep ending up passing so many parameters or finding the need for a factory method sort of approach (which I don't think we're using elsewhere), so I just wanted to run it by you in its current state. Could you take a look and let me know if you see any good ways to further divide up this component? Thanks!