### PR TITLE
Emit `ready` event after Leaflet map is loaded

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -5,7 +5,14 @@
 </template>
 
 <script>
-import { onMounted, onBeforeUnmount, computed, reactive, ref } from "vue";
+import {
+  onMounted,
+  onBeforeUnmount,
+  computed,
+  reactive,
+  ref,
+  nextTick,
+} from "vue";
 import {
   remapEvents,
   propsBinder,
@@ -345,6 +352,7 @@ export default {
       );
       DomEvent.on(blueprint.leafletRef, listeners);
       blueprint.ready = true;
+      nextTick(() => context.emit("ready"));
     });
 
     onBeforeUnmount(() => {


### PR DESCRIPTION
Resolves #42 by allowing Leaflet setup code to be run only after the underlying map is loaded and ready to be used.