### PR TITLE
Remove dependence on `L.latLng` function entirely from LMarker component

### DIFF
--- a/src/Playground.vue
+++ b/src/Playground.vue
@@ -116,7 +116,6 @@
 
         <l-circle :lat-lng="[35.865, 12.865]" :radius="10000" color="green" />
         <l-geo-json :geojson="geojson"></l-geo-json>
-
       </l-map>
       <button @click="changeIcon">New kitten icon</button>
       <label for="attributionPrefix">Attribution prefix:</label>

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -1,12 +1,6 @@
 <script>
 import { onMounted, ref, provide, inject } from "vue";
-import {
-  remapEvents,
-  propsBinder,
-  debounce,
-  provideLeafletWrapper,
-  updateLeafletWrapper,
-} from "../utils.js";
+import { remapEvents, propsBinder, debounce } from "../utils.js";
 import { props, setup as markerSetup } from "../functions/marker";
 import { render } from "../functions/layer";
 
@@ -22,7 +16,6 @@ export default {
 
     const addLayer = inject("addLayer");
 
-    const latLng = provideLeafletWrapper("latLng");
     provide("canSetParentHtml", () => !!leafletRef.value.getElement());
     provide(
       "setParentHtml",
@@ -35,13 +28,9 @@ export default {
     const { options, methods } = markerSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const {
-        marker,
-        DomEvent,
-        latLng: leafletLatLng,
-        setOptions,
-      } = await import("leaflet/dist/leaflet-src.esm");
-      updateLeafletWrapper(latLng, leafletLatLng);
+      const { marker, DomEvent, setOptions } = await import(
+        "leaflet/dist/leaflet-src.esm"
+      );
 
       leafletRef.value = marker(props.latLng, options);
 

--- a/src/functions/marker.js
+++ b/src/functions/marker.js
@@ -1,4 +1,3 @@
-import { inject } from "vue";
 import { props as layerProps, setup as layerSetup } from "../functions/layer";
 
 export const props = {
@@ -38,7 +37,6 @@ export const setup = (props, leafletRef, context) => {
     ...layerOptions,
     ...props,
   };
-  const latLng = inject("latLng");
 
   const methods = {
     ...layerMethods,
@@ -60,12 +58,8 @@ export const setup = (props, leafletRef, context) => {
 
       if (leafletRef.value) {
         const oldLatLng = leafletRef.value.getLatLng();
-        const newLatLng = latLng(newVal);
-        if (
-          newLatLng.lat !== oldLatLng.lat ||
-          newLatLng.lng !== oldLatLng.lng
-        ) {
-          leafletRef.value.setLatLng(newLatLng);
+        if (!oldLatLng || !oldLatLng.equals(newVal)) {
+          leafletRef.value.setLatLng(newVal);
         }
       }
     },


### PR DESCRIPTION
Resolves #47. I have still not figured out why the old code worked locally in this repo, but not when bundled and added into another app, which is somewhat unsatisfying. However, I _did_ realize that we could sidestep the issue entirely at least in this instance.

As per [Leaflet's latLng docs](https://leafletjs.com/reference-1.7.1.html#latlng), "All Leaflet methods that accept LatLng objects also accept them in a simple Array form and simple object form". So instead of converting the `newVal` received by `setLatLng` to a LatLng object and then comparing that against the old value (that is already a LatLng object), we can simply pass whatever value we receive to the `equals` method on the old LatLng.