### PR TITLE
fix: import icons with dynamic import and not require

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -213,7 +213,7 @@ export default {
         DomEvent,
         setOptions,
       } = await import("leaflet/dist/leaflet-src.esm");
-      resetWebpackIcon(Icon);
+      await resetWebpackIcon(Icon);
       options.crs = options.crs || CRS.EPSG3857;
 
       const methods = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,13 +65,19 @@ export const remapEvents = (contextAttrs) => {
   return result;
 };
 
-export const resetWebpackIcon = (Icon) => {
+export const resetWebpackIcon = async (Icon) => {
+  const modules = await Promise.all([
+    import("leaflet/dist/images/marker-icon-2x.png"),
+    import("leaflet/dist/images/marker-icon.png"),
+    import("leaflet/dist/images/marker-shadow.png"),
+  ]);
+
   delete Icon.Default.prototype._getIconUrl;
 
   Icon.Default.mergeOptions({
-    iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),
-    iconUrl: require("leaflet/dist/images/marker-icon.png"),
-    shadowUrl: require("leaflet/dist/images/marker-shadow.png"),
+    iconRetinaUrl: modules[0].default,
+    iconUrl: modules[1].default,
+    shadowUrl: modules[2].default,
   });
 };
 


### PR DESCRIPTION
fixes #57 

Since we are using `import()` already everywhere we should not mix it with `require`, fixed it.