### PR TITLE
Quick-fix leaflet import docs

### DIFF
--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -22,7 +22,7 @@ yarn add leaflet @vue-leaflet/vue-leaflet
 
 ### In a webpack / rollup build system
 
-#### System wide components
+#### System-wide components
 
 ```js
 import Vue from "vue";
@@ -34,14 +34,24 @@ Vue.component("l-tile-layer", LTileLayer);
 Vue.component("l-marker", LMarker);
 ```
 
+If you need a globally available `L`, such as for compatibility
+with some plugins, be sure to explicitly import Leaflet from the
+ES2015 module used by vue-leaflet.
+```js
+import * as L from "leaflet/dist/leaflet-src.esm";
+
+window.L = L;
+```
+
 #### Locally installed components
 
 ##### In your component:
 
 ```js
-// If you need to reference 'L', such as in 'L.icon', then be sure to
-// explicitly import 'leaflet' into your component
-import L from "leaflet";
+// If you need to reference 'L', such as to create latLng instances,
+// then be sure to explicitly import 'leaflet' from the ES2015
+// module used by vue-leaflet.
+import { latLng } from "leaflet/dist/leaflet-src.esm";
 import { LMap, LTileLayer, LMarker } from "vue-leaflet";
 
 export default {


### PR DESCRIPTION
As discussed in #48 the documentation will need potentially significant upgrades around importing Leaflet from its ES2015 bundle instead of the base package. This is a quick stab at getting the basics in place for the quick start, as an interim solution.