### PR TITLE
fix: add missing parentheses in index.js

### DIFF
--- a/src/playground/index.js
+++ b/src/playground/index.js
@@ -20,12 +20,19 @@ const routes = [
   {
     path: "/control-scale",
     component: () => import("./views/ControlScale.vue"),
+  },
+  {
     path: "/control-layers",
     component: () => import("./views/ControlLayers.vue"),
-  { path: "/control-zoom", component: () => import("./views/ControlZoom.vue") },
+  },
+  {
+    path: "/control-zoom",
+    component: () => import("./views/ControlZoom.vue"),
+  },
   {
     path: "/control-attribution",
     component: () => import("./views/ControlAttribution.vue"),
+  },
   { path: "/icon", component: () => import("./views/Icon.vue") },
   {
     path: "/control-custom-message",


### PR DESCRIPTION
Hi @DonNicoJs  I found and added some missing parentheses in `index.js` which were causing errors.