### PR TITLE
Playground fix draggable l marker

### DIFF
--- a/src/playground/views/Popups.vue
+++ b/src/playground/views/Popups.vue
@@ -6,19 +6,14 @@
       name="OpenStreetMap"
     ></l-tile-layer>
 
-    <l-marker
-      :lat-lng="[41.8329, -87.7327]"
-      draggable
-      @moveend="log('moveend')"
-      :options="{ riseOnHover: true, riseOffset: 300 }"
-    >
+    <l-marker :lat-lng="[41.8329, -87.7327]">
       <l-popup>
         Hi! I'm staying here on this location!
       </l-popup>
     </l-marker>
 
     <l-layer-group>
-      <l-marker :lat-lng="[41.75, -87.65]" draggable @moveend="log('moveend')">
+      <l-marker :lat-lng="[41.75, -87.65]" draggable>
         <l-popup>
           Hi! You can drag me around!
         </l-popup>

--- a/src/playground/views/Tooltips.vue
+++ b/src/playground/views/Tooltips.vue
@@ -6,19 +6,14 @@
       name="OpenStreetMap"
     ></l-tile-layer>
 
-    <l-marker
-      :lat-lng="[41.8329, -87.7327]"
-      draggable
-      @moveend="log('moveend')"
-      :options="{ riseOnHover: true, riseOffset: 300 }"
-    >
+    <l-marker :lat-lng="[41.8329, -87.7327]">
       <l-tooltip>
         Hi! I'm staying here on this location!
       </l-tooltip>
     </l-marker>
 
     <l-layer-group>
-      <l-marker :lat-lng="[41.75, -87.65]" draggable @moveend="log('moveend')">
+      <l-marker :lat-lng="[41.75, -87.65]" draggable>
         <l-tooltip>
           Hi! You can drag me around!
         </l-tooltip>


### PR DESCRIPTION
In the `Tooltips` and `Popups` components the draggable `l-marker` was draggable only the first time, after that it was not possible to drag it, neither the map.
I removed the `@moveend="log('moveend')` parameter in the `l-marker` that seemed to have created the issue described above.
I admit that even if I didn't completely understand why, removing it made the `l-marker` dragging working again.
Since I just kept it from the "old playground" without any particular reason, I propose to remove it with this PR in order to fix this issue.
Let me know if in your opinion this could work.
Thank you :)