### PR TITLE
docs: fix draggable marker

### DIFF
--- a/src/playground/views/Marker.vue
+++ b/src/playground/views/Marker.vue
@@ -6,7 +6,7 @@
       name="OpenStreetMap"
     ></l-tile-layer>
 
-    <l-marker :lat-lng="[50, 50]" draggable> </l-marker>
+    <l-marker :lat-lng="coordinates" draggable> </l-marker>
   </l-map>
 </template>
 <script>
@@ -21,6 +21,7 @@ export default {
   data() {
     return {
       zoom: 2,
+      coordinates: [50, 50],
     };
   },
 };

--- a/src/playground/views/Popups.vue
+++ b/src/playground/views/Popups.vue
@@ -13,7 +13,7 @@
     </l-marker>
 
     <l-layer-group>
-      <l-marker :lat-lng="[41.75, -87.65]" draggable>
+      <l-marker :lat-lng="coordinates" draggable>
         <l-popup>
           Hi! You can drag me around!
         </l-popup>
@@ -107,6 +107,7 @@ export default {
   data() {
     return {
       zoom: 9,
+      coordinates: [41.75, -87.65],
     };
   },
 };

--- a/src/playground/views/Tooltips.vue
+++ b/src/playground/views/Tooltips.vue
@@ -13,7 +13,7 @@
     </l-marker>
 
     <l-layer-group>
-      <l-marker :lat-lng="[41.75, -87.65]" draggable>
+      <l-marker :lat-lng="coordinates" draggable>
         <l-tooltip>
           Hi! You can drag me around!
         </l-tooltip>
@@ -107,6 +107,7 @@ export default {
   data() {
     return {
       zoom: 9,
+      coordinates: [41.75, -87.65],
     };
   },
 };


### PR DESCRIPTION
As stated in issue #81  in the components: `Marker`, `Popups` and `Tooltips` the position of the draggable `l-marker` was resetting every time the user zoomed in or out. Assigning latitudinal and longitudinal values of the `l-marker` into a variable inside `data()` seems to fix the issue.

@DonNicoJs let me know what do you think about this.

Thank you :)