### PR TITLE
fix: 🐛 Import leaflet inside Lmap from the default module entry

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -211,7 +211,7 @@ export default {
 
     onMounted(async () => {
       const { map, CRS, Icon, latLngBounds, latLng, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
+        "leaflet"
       );
       await resetWebpackIcon(Icon);
       options.crs = options.crs || CRS.EPSG3857;


### PR DESCRIPTION
Importing leaflet from the deep import "leaflet/dist/leaflet-src.esm" makes it impossible  to use vue-leaflet with several community plugins that rely  on using the default export. This change makes LMap use Leaflet default module entry fixing issues with plugins that hook  and mutate the `L` object. 

Fixes #35 