### PR TITLE
Update readme with details about using async import for Leaflet components

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ This is a Beta version! And may yet be instable! If you want to help please reac
 
 ## What Works:
 
+- LCircle
+- LCircleMarker
+- LControl
+- LControlAttribution
 - LControlLayers
+- LControlScale
+- LControlZoom
+- LFeatureGroup
+- LGeoJson
 - LIcon
 - LMap
 - LMarker
@@ -16,6 +24,7 @@ This is a Beta version! And may yet be instable! If you want to help please reac
 - LRectangle
 - LTileLayer
 - LTooltip
+- LWmsTileLayer
 
 Note that unlikely the version for vue2 this version is fully compatible with SSR
 

--- a/README.md
+++ b/README.md
@@ -38,4 +38,55 @@ or
 
 ## Usage
 
-Till the documentation is ready please check the [demo project](https://github.com/vue-leaflet/vue3-demo-project/blob/master/src/App.vue)
+Until the complete documentation is ready, please check the [demo project](https://github.com/vue-leaflet/vue3-demo-project/blob/master/src/App.vue) for example usage.
+
+### Working with Leaflet
+
+> **N.B.** Using `import L from "leaflet"` or `import { ... } from "leaflet"` can lead to unexpected errors.
+
+To provide server-side rendering and tree-shaking capabilities, vue-leaflet uses async imports from the Leaflet ESM.
+This can lead to issues when importing additional methods from Leaflet, because the two instances of the Leaflet
+classes are technically no longer the same. See [Issue 48](https://github.com/vue-leaflet/vue-leaflet/issues/48) for more.
+
+To avoid these issues, import any Leaflet methods asynchronously in response to the LMap component's `@ready` event:
+```vue
+<template>
+  <l-map>
+    <l-geo-json :geojson="geojson" :options="geojsonOptions" />
+  </l-map>
+</template>
+
+<script>
+// DON'T load Leaflet components here!
+import { LMap, LGeoJson } from "./../../components";
+
+export default {
+  components: {
+    LMap,
+    LGeoJson,
+  },
+  data() {
+    return {
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          // ...
+        ],
+      },
+      geojsonOptions: {
+        // Options that don't rely on Leaflet methods.
+      },
+    };
+  },
+  async beforeMount() {
+    // HERE is where to load Leaflet components!
+    const { circleMarker } = await import("leaflet/dist/leaflet-src.esm");
+
+    // And now the Leaflet circleMarker function can be used by the options:
+    this.geojsonOptions.pointToLayer = (feature, latLng) =>
+      circleMarker(latLng, { radius: 8 });
+    this.mapIsReady = true;
+  },
+};
+</script>
+```

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ This is a Beta version! And may yet be instable! If you want to help, please rea
 
 ## Installation
 
-`npm i @vue-leaflet/vue-leaflet`
+`yarn add @vue-leaflet/vue-leaflet`
 
 or
 
-`yarn add @vue-leaflet/vue-leaflet`
+`npm i -D @vue-leaflet/vue-leaflet`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vue-leaflet
 
-Vue-leaflet written and compatible with vue3
+Vue-leaflet, written and compatible with Vue 3!
 
-This is a Beta version! And may yet be instable! If you want to help please reach out in an issue or [discord](https://discord.gg/uVZAfUf)
+This is a Beta version! And may yet be instable! If you want to help, please reach out in an issue or on [discord](https://discord.gg/uVZAfUf).
 
 ## What Works:
 
@@ -26,7 +26,7 @@ This is a Beta version! And may yet be instable! If you want to help please reac
 - LTooltip
 - LWmsTileLayer
 
-Note that unlikely the version for vue2 this version is fully compatible with SSR
+> Note that unlike the [Vue 2 version](https://github.com/vue-leaflet/Vue2Leaflet), this library is fully compatible with SSR.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Vue-leaflet, written and compatible with Vue 3!
 
-This is a Beta version! And may yet be instable! If you want to help, please reach out in an issue or on [discord](https://discord.gg/uVZAfUf).
+This is a Beta version! And may yet be instable! If you want to help, please reach out in an
+[issue](https://github.com/vue-leaflet/vue-leaflet/issues) or on [discord](https://discord.gg/uVZAfUf).
 
 ## What Works:
 


### PR DESCRIPTION
There was another request for help on discord today that was because of the problems caused by importing from `"leaflet"` in application code, while the library async imports from `"leaflet/dist/leaflet.esm.js"`, leading to two incompatible instances of the Leaflet classes.

So the main point of this PR is that I've added an explicit example to the readme, and a bit of explanation about why this approach is needed, in the Usage section at the bottom.

While working on it, I also updated the list of working components and tweaked the language and formatting in a few places.