### PR TITLE
Allow Leaflet CRSs to be specified by name

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -95,11 +95,14 @@ export default {
       default: false,
     },
     /**
-     * The crs option for the map
-     * @values CRS.EPSG3857
+     * The CRS to use for the map. Can be an object that defines a coordinate reference
+     * system for projecting geographical points into screen coordinates and back
+     * (see https://leafletjs.com/reference-1.7.1.html#crs-l-crs-base), or a string
+     * name identifying one of Leaflet's defined CRSs, such as "EPSG4326".
      */
     crs: {
-      type: Object,
+      type: [String, Object],
+      default: "EPSG3857",
     },
     maxBoundsViscosity: {
       type: Number,
@@ -214,7 +217,10 @@ export default {
         "leaflet/dist/leaflet-src.esm"
       );
       await resetWebpackIcon(Icon);
-      options.crs = options.crs || CRS.EPSG3857;
+
+      const optionsCrs =
+        typeof options.crs == "string" ? CRS[options.crs] : options.crs;
+      options.crs = optionsCrs || CRS.EPSG3857;
 
       const methods = {
         addLayer(layer) {


### PR DESCRIPTION
An issue was raised on the discord that setting the `:crs` property of an `LMap` component cannot be reliably accomplished while also importing the desired CRS object from Leaflet asynchronously, as recommended in our readme. The reason for this is that while some component lifecycle methods are allowed to be async functions, they are not actually awaited by Vue, but simply executed synchronously. Therefore awaiting the import of a CRS from `leaflet/dist/leaflet-src.esm` is likely to complete _after_ the child map has been created, even if called in `beforeCreate` of the component containing the `LMap`.

This PR updates the `:crs` property to also accept a string, and use the matching property in the `L.CRS` imported in the `LMap`'s `onMounted` hook, if it exists. This still allows fully custom CRS objects to be defined manually, if desired. The default CRS remains EPSG3857, which is used either if a string is provided that does not correspond to a defined `L.CRS` entry, or if the prop is not specified.