### PR TITLE
Add `minZoom` and `maxZoom` props to grid layer

### DIFF
--- a/src/functions/gridLayer.js
+++ b/src/functions/gridLayer.js
@@ -23,6 +23,14 @@ export const props = {
     type: Boolean,
     default: false,
   },
+  minZoom: {
+    type: Number,
+    default: 0,
+  },
+  maxZoom: {
+    type: Number,
+    default: undefined,
+  },
 };
 
 export const setup = (props, leafletRef) => {
@@ -37,6 +45,8 @@ export const setup = (props, leafletRef) => {
     zIndex: props.zIndex,
     tileSize: props.tileSize,
     noWrap: props.noWrap,
+    minZoom: props.minZoom,
+    maxZoom: props.maxZoom,
   };
   return { options, methods: { ...layerMethods } };
 };

--- a/src/playground/App.vue
+++ b/src/playground/App.vue
@@ -3,6 +3,7 @@
     <div class="menu">
       <router-link to="/">Home</router-link>
       <router-link to="/grid-layer">GridLayer</router-link>
+      <router-link to="/tile-layer">TileLayer</router-link>
       <router-link to="/feature-group">Feature Group</router-link>
       <router-link to="/circle">Circle</router-link>
       <router-link to="/circle-marker">CircleMarker</router-link>

--- a/src/playground/index.js
+++ b/src/playground/index.js
@@ -36,6 +36,7 @@ const routes = [
   { path: "/geo-json", component: () => import("./views/GeoJSON.vue") },
   { path: "/icon", component: () => import("./views/Icon.vue") },
   { path: "/marker", component: () => import("./views/Marker.vue") },
+  { path: "/tile-layer", component: () => import("./views/TileLayer.vue") },
   { path: "/polygon", component: () => import("./views/Polygon.vue") },
   { path: "/polyline", component: () => import("./views/Polyline.vue") },
   { path: "/popups", component: () => import("./views/Popups.vue") },

--- a/src/playground/views/TileLayer.vue
+++ b/src/playground/views/TileLayer.vue
@@ -1,0 +1,33 @@
+<template>
+  <l-map ref="map" v-model:zoom="zoom" :center="[47.41322, -1.219482]">
+    <l-tile-layer
+      url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      layer-type="base"
+      name="OpenStreetMap"
+      max-zoom="10"
+    />
+    <l-tile-layer
+      url="https://s3.amazonaws.com/te512.safecast.org/{z}/{x}/{y}.png"
+      attribution="<a href='https://blog.safecast.org/about/'>SafeCast</a> (<a href='https://creativecommons.org/licenses/by-sa/3.0/'>CC-BY-SA</a>"
+      min-zoom="5"
+      max-zoom="7"
+    />
+  </l-map>
+</template>
+<script>
+import { LMap, LTileLayer } from "./../../components";
+
+export default {
+  components: {
+    LMap,
+    LTileLayer,
+  },
+  data() {
+    return {
+      zoom: 2,
+    };
+  },
+};
+</script>
+
+<style></style>


### PR DESCRIPTION
Resolves #91. The `minZoom` and `maxZoom` props added to the LGridLayer component are inherited by and available to the LTileLayer component as well.

I also added a new demo page to the playground, showing a second tile layer on top of the OSM base layer, that is only displayed on zoom levels 5-7.