### PR TITLE
added missing context param for setup in layer.js

### DIFF
--- a/src/components/LGridLayer.vue
+++ b/src/components/LGridLayer.vue
@@ -22,7 +22,7 @@ export default {
 
     const addLayer = inject("addLayer");
 
-    const { options, methods } = gridLayerSetup(props, leafletRef);
+    const { options, methods } = gridLayerSetup(props, leafletRef, context);
 
     onMounted(async () => {
       const { GridLayer, DomEvent, DomUtil } = await import(

--- a/src/components/LLayerGroup.vue
+++ b/src/components/LLayerGroup.vue
@@ -12,7 +12,7 @@ export default {
 
     const addLayer = inject("addLayer");
 
-    const { methods } = layerGroupSetup(props, leafletRef);
+    const { methods } = layerGroupSetup(props, leafletRef, context);
 
     onMounted(async () => {
       const { layerGroup, DomEvent } = await import(

--- a/src/functions/gridLayer.js
+++ b/src/functions/gridLayer.js
@@ -33,10 +33,11 @@ export const props = {
   },
 };
 
-export const setup = (props, leafletRef) => {
+export const setup = (props, leafletRef, context) => {
   const { options: layerOptions, methods: layerMethods } = layerSetup(
     props,
-    leafletRef
+    leafletRef,
+    context
   );
   const options = {
     ...layerOptions,

--- a/src/functions/layerGroup.js
+++ b/src/functions/layerGroup.js
@@ -5,10 +5,11 @@ export const props = {
   ...layerProps,
 };
 
-export const setup = (props, leafletRef) => {
+export const setup = (props, leafletRef, context) => {
   const { options: layerOptions, methods: layerMethods } = layerSetup(
     props,
-    leafletRef
+    leafletRef,
+    context
   );
 
   const options = {


### PR DESCRIPTION
LLayerGroup component has an error:
`TypeError: Cannot read property 'emit' of undefined`

I added missing contex param to all setup calls of layer.js