### PR TITLE
LIMageOverlay support with playground demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is a Beta version! And may yet be instable! If you want to help, please rea
 - LFeatureGroup
 - LGeoJson
 - LIcon
+- LImageOverlay
 - LMap
 - LMarker
 - LPolygon

--- a/src/components/LImageOverlay.vue
+++ b/src/components/LImageOverlay.vue
@@ -1,0 +1,48 @@
+<script>
+import { onMounted, ref, inject, nextTick } from "vue";
+import { remapEvents, propsBinder } from "../utils.js";
+import {
+  props as imageOverlayProps,
+  setup as imageOverlaySetup,
+} from "../functions/imageOverlay";
+import { render } from "../functions/layer";
+
+/**
+ * ImageOverlay component, render a plain image instead of a geospatial map.
+ */
+export default {
+  name: "LImageOverlay",
+  props: imageOverlayProps,
+  setup(props, context) {
+    const leafletRef = ref({});
+    const ready = ref(false);
+
+    const addLayer = inject("addLayer");
+
+    const { options, methods } = imageOverlaySetup(props, leafletRef, context);
+
+    onMounted(async () => {
+      const { imageOverlay, DomEvent } = await import(
+        "leaflet/dist/leaflet-src.esm"
+      );
+      leafletRef.value = imageOverlay(props.url, props.bounds, options);
+
+      const listeners = remapEvents(context.attrs);
+      DomEvent.on(leafletRef.value, listeners);
+      propsBinder(methods, leafletRef.value, props);
+      addLayer({
+        ...props,
+        ...methods,
+        leafletObject: leafletRef.value,
+      });
+      ready.value = true;
+      nextTick(() => context.emit("ready", leafletRef.value));
+    });
+
+    return { ready, leafletObject: leafletRef };
+  },
+  render() {
+    return render(this.ready, this.$slots);
+  },
+};
+</script>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ export { default as LFeatureGroup } from "./LFeatureGroup.vue";
 export { default as LGeoJson } from "./LGeoJson.vue";
 export { default as LGridLayer } from "./LGridLayer.vue";
 export { default as LIcon } from "./LIcon.vue";
+export { default as LImageOverlay } from "./LImageOverlay.vue";
 export { default as LLayerGroup } from "./LLayerGroup.vue";
 export { default as LMap } from "./LMap.vue";
 export { default as LMarker } from "./LMarker.vue";

--- a/src/functions/imageOverlay.js
+++ b/src/functions/imageOverlay.js
@@ -10,7 +10,7 @@ export const props = {
     required: true,
   },
   bounds: {
-    type: Array,
+    type: [Array, Object],
     required: true,
   },
   opacity: {

--- a/src/functions/imageOverlay.js
+++ b/src/functions/imageOverlay.js
@@ -1,0 +1,119 @@
+import { props as layerProps, setup as layerSetup } from "./layer";
+/**
+ * @typedef {import('leaflet/dist/leaflet-src.esm.js').LatLngBounds} LatLngBounds
+ */
+
+export const props = {
+  ...layerProps,
+  url: {
+    type: String,
+    required: true,
+  },
+  bounds: {
+    type: Array,
+    required: true,
+  },
+  opacity: {
+    type: Number,
+    custom: true,
+    default: 1.0,
+  },
+  alt: {
+    type: String,
+    default: "",
+  },
+  interactive: {
+    type: Boolean,
+    default: false,
+  },
+  crossOrigin: {
+    type: Boolean,
+    default: false,
+  },
+  errorOverlayUrl: {
+    type: String,
+    custom: true,
+    default: "",
+  },
+  zIndex: {
+    type: Number,
+    custom: true,
+    default: 1,
+  },
+  className: {
+    type: String,
+    default: "",
+  },
+};
+
+export const setup = (setupProps, LeafletRef, context) => {
+  const { options: layerOptions, methods: layerMethods } = layerSetup(
+    setupProps,
+    LeafletRef,
+    context
+  );
+  const options = {
+    ...layerOptions,
+    ...setupProps,
+  };
+
+  const methods = {
+    ...layerMethods,
+    /**
+     * Sets the opacity of the overlay.
+     * @param {number} opacity
+     */
+    setOpacity(opacity) {
+      return LeafletRef.value.setOpacity(opacity);
+    },
+    /**
+     * Changes the URL of the image.
+     * @param {string} url
+     */
+    setUrl(url) {
+      return LeafletRef.value.setUrl(url);
+    },
+    /**
+     * Update the bounds that this ImageOverlay covers
+     * @param {LatLngBounds | Array<Array<number>>} bounds
+     */
+    setBounds(bounds) {
+      return LeafletRef.value.setBounds(bounds);
+    },
+    /**
+     * Get the bounds that this ImageOverlay covers
+     * @returns {LatLngBounds}
+     */
+    getBounds() {
+      return LeafletRef.value.getBounds();
+    },
+    /**
+     * Returns the instance of HTMLImageElement used by this overlay.
+     * @returns {HTMLElement}
+     */
+    getElement() {
+      return LeafletRef.value.getElement();
+    },
+    /**
+     * Brings the layer to the top of all overlays.
+     */
+    bringToFront() {
+      return LeafletRef.value.bringToFront();
+    },
+    /**
+     * Brings the layer to the bottom of all overlays.
+     */
+    bringToBack() {
+      return LeafletRef.value.bringToBack();
+    },
+    /**
+     * Changes the zIndex of the image overlay.
+     * @param {number} zIndex
+     */
+    setZIndex(zIndex) {
+      return LeafletRef.value.setZIndex(zIndex);
+    },
+  };
+
+  return { options, methods };
+};

--- a/src/playground/App.vue
+++ b/src/playground/App.vue
@@ -4,6 +4,7 @@
       <router-link to="/">Home</router-link>
       <router-link to="/grid-layer">GridLayer</router-link>
       <router-link to="/tile-layer">TileLayer</router-link>
+      <router-link to="/image-overlay">ImageOverlay</router-link>
       <router-link to="/feature-group">Feature Group</router-link>
       <router-link to="/circle">Circle</router-link>
       <router-link to="/circle-marker">CircleMarker</router-link>

--- a/src/playground/index.js
+++ b/src/playground/index.js
@@ -37,6 +37,10 @@ const routes = [
   { path: "/icon", component: () => import("./views/Icon.vue") },
   { path: "/marker", component: () => import("./views/Marker.vue") },
   { path: "/tile-layer", component: () => import("./views/TileLayer.vue") },
+  {
+    path: "/image-overlay",
+    component: () => import("./views/ImageOverlay.vue"),
+  },
   { path: "/polygon", component: () => import("./views/Polygon.vue") },
   { path: "/polyline", component: () => import("./views/Polyline.vue") },
   { path: "/popups", component: () => import("./views/Popups.vue") },

--- a/src/playground/views/ImageOverlay.vue
+++ b/src/playground/views/ImageOverlay.vue
@@ -1,0 +1,94 @@
+<template>
+  <l-map
+    ref="map"
+    v-model:zoom="zoom"
+    :crs="crs"
+    :center="[height / 2, width / 2]"
+    :minZoom="-5"
+  >
+    <l-image-overlay :url="imageOverlayUrl" :bounds="bounds"></l-image-overlay>
+
+    <l-marker
+      v-for="(marker, idx) in markers"
+      :key="idx"
+      :lat-lng="marker.coordinates"
+      ><l-popup>{{ idx }}</l-popup></l-marker
+    >
+  </l-map>
+
+  <!-- Map Settings -->
+  <label for="imageOverlayUrl">Url to render: </label>
+  <input
+    type="text"
+    id="imageOverlayUrl"
+    placeholder="Url for image overlay"
+    v-model="imageOverlayUrl"
+  />
+  <!-- Bounds settings -->
+  <label for="width">Width: </label>
+  <input type="number" id="width" placeholder="Width" v-model="width" />
+  <label for="height">Height: </label>
+  <input type="number" id="height" placeholder="Height" v-model="height" />
+
+  <!-- Marker settings -->
+  <div class="markers-list">
+    <h4>Markers</h4>
+    <ul>
+      <li v-for="(marker, idx) in markers" :key="idx">
+        {{ idx }} - lng (X): {{ marker.coordinates.lng }} - lat (Y):
+        {{ marker.coordinates.lat }}
+      </li>
+    </ul>
+  </div>
+</template>
+<script>
+import { ref, computed } from "vue";
+import { LMap, LImageOverlay, LMarker, LPopup } from "./../../components";
+import { CRS } from "leaflet/dist/leaflet-src.esm";
+
+export default {
+  components: {
+    LMap,
+    LImageOverlay,
+    LMarker,
+    LPopup,
+  },
+  setup() {
+    const imageOverlayUrl = ref(
+      "https://www.printablee.com/postpic/2011/06/blank-100-square-grid-paper_405041.jpg"
+    );
+    const width = ref(100);
+    const height = ref(100);
+    const zoom = ref(1);
+
+    const markers = ref([
+      { coordinates: { lng: 0, lat: 0 } },
+      { coordinates: { lng: 100, lat: 0 } },
+      { coordinates: { lng: 0, lat: 100 } },
+      { coordinates: { lng: 100, lat: 100 } },
+      { coordinates: { lng: 0, lat: 50 } },
+      { coordinates: { lng: 50, lat: 0 } },
+      { coordinates: { lng: 50, lat: 100 } },
+      { coordinates: { lng: 100, lat: 50 } },
+    ]);
+
+    const bounds = computed(() => [
+      [0, 0],
+      [height.value, width.value],
+    ]);
+    const crs = CRS.Simple;
+
+    return {
+      imageOverlayUrl,
+      width,
+      height,
+      zoom,
+      markers,
+      bounds,
+      crs,
+    };
+  },
+};
+</script>
+
+<style></style>


### PR DESCRIPTION
Ported from vue2-leaflet.
+ added missing setZIndex method.
+ added jsdoc with type information for methods.
Closes #13

I'm not sure if I did everything correct, please correct me if something is wrong.
Looking forward to being able to use TypeScript to develop vue-leaflet, it was strange for me to code in js without TS.

![image](https://user-images.githubusercontent.com/5204006/108559607-d0c71d80-72fb-11eb-82ee-b5c7604f393c.png)
