### PR TITLE
Update demo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ or
 
 ## Usage
 
-Until the complete documentation is ready, please check the [demo project](https://github.com/vue-leaflet/vue3-demo-project/blob/master/src/App.vue) for example usage.
+Until the complete documentation is ready, please check the
+[component playground](https://github.com/vue-leaflet/vue-leaflet/tree/master/src/playground/views) examples or the
+[demo project](https://github.com/vue-leaflet/vue3-demo-project/blob/master/src/App.vue) for usage with Vue 3.
+Most component props mimic the vanilla [Leaflet options](https://leafletjs.com/reference-1.7.1.html) as closely as
+possible, and generally remain the same as in their [Vue2Leaflet counterparts](https://vue2-leaflet.netlify.app/components/).
 
 ### Working with Leaflet
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,16 @@ classes are technically no longer the same. See [Issue 48](https://github.com/vu
 To avoid these issues, import any Leaflet methods asynchronously in response to the LMap component's `@ready` event:
 ```vue
 <template>
-  <l-map>
+  <l-map style="height:50vh">
     <l-geo-json :geojson="geojson" :options="geojsonOptions" />
   </l-map>
 </template>
 
 <script>
 // DON'T load Leaflet components here!
-import { LMap, LGeoJson } from "./../../components";
+// Its CSS is needed though, if not imported elsewhere in your application.
+import "leaflet/dist/leaflet.css"
+import { LMap, LGeoJson } from "@vue-leaflet/vue-leaflet";
 
 export default {
   components: {


### PR DESCRIPTION
As per a discussion on discord today, the sample displayed in the readme does not actually result in a map displayed on the page if simply copied and pasted. While it's not intended to be a quickstart, it should also be functional since it's reasonable to assume that many devs will copy and paste the first code they find and expect it to work :)

This PR accomplishes that, and also updates the "Usage" paragraph to point to the more recent demo source in the vue-leaflet playground views, as well as the props documentation for Vue2Leaflet, which still largely holds in many instances.