### PR TITLE
Make `useGlobalLeaflet` a prop of `LMap` only, and provide it for use in all child components

### DIFF
--- a/src/components/LCircle.vue
+++ b/src/components/LCircle.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as circleSetup } from "../functions/circle";
 import { render } from "../functions/layer";
 
@@ -14,12 +19,15 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = circleSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { circle, DomEvent } = await import("leaflet/dist/leaflet-src.esm");
+      const { circle, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = circle(props.latLng, options);
 

--- a/src/components/LCircleMarker.vue
+++ b/src/components/LCircleMarker.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as circleMarkerSetup } from "../functions/circleMarker";
 import { render } from "../functions/layer";
 
@@ -14,14 +19,15 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = circleMarkerSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { circleMarker, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { circleMarker, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = circleMarker(props.latLng, options);
 

--- a/src/components/LControl.vue
+++ b/src/components/LControl.vue
@@ -5,7 +5,7 @@ import {
   setup as controlSetup,
   render,
 } from "../functions/control";
-import { propsBinder } from "../utils.js";
+import { propsBinder, WINDOW_OR_GLOBAL, GLOBAL_LEAFLET_OPT } from "../utils.js";
 
 export default {
   name: "LControl",
@@ -26,12 +26,15 @@ export default {
     const leafletRef = ref({});
     const root = ref(null);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const registerControl = inject("registerControl");
+
     const { options, methods } = controlSetup(props, leafletRef);
+
     onMounted(async () => {
-      const { Control, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { Control, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       const LControl = Control.extend({
         onAdd() {

--- a/src/components/LControlAttribution.vue
+++ b/src/components/LControlAttribution.vue
@@ -4,7 +4,7 @@ import {
   props,
   setup as attributionControlSetup,
 } from "../functions/controlAttribution";
-import { propsBinder } from "../utils.js";
+import { propsBinder, WINDOW_OR_GLOBAL, GLOBAL_LEAFLET_OPT } from "../utils.js";
 
 export default {
   name: "LControlAttribution",
@@ -12,10 +12,15 @@ export default {
   setup(props, context) {
     const leafletRef = ref({});
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const registerControl = inject("registerControl");
+
     const { options, methods } = attributionControlSetup(props, leafletRef);
+
     onMounted(async () => {
-      const { control } = await import("leaflet/dist/leaflet-src.esm");
+      const { control } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = control.attribution(options);
       propsBinder(methods, leafletRef.value, props);

--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -1,7 +1,7 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
 import { props, setup as layerControlSetup } from "../functions/controlLayers";
-import { propsBinder } from "../utils.js";
+import { propsBinder, WINDOW_OR_GLOBAL, GLOBAL_LEAFLET_OPT } from "../utils.js";
 
 export default {
   name: "LControlLayers",
@@ -9,10 +9,15 @@ export default {
   setup(props, context) {
     const leafletRef = ref({});
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const registerLayerControl = inject("registerLayerControl");
+
     const { options, methods } = layerControlSetup(props, leafletRef);
+
     onMounted(async () => {
-      const { control } = await import("leaflet/dist/leaflet-src.esm");
+      const { control } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = control.layers(null, null, options);
 

--- a/src/components/LControlScale.vue
+++ b/src/components/LControlScale.vue
@@ -1,7 +1,7 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
 import { props, setup as scaleControlSetup } from "../functions/controlScale";
-import { propsBinder } from "../utils.js";
+import { propsBinder, WINDOW_OR_GLOBAL, GLOBAL_LEAFLET_OPT } from "../utils.js";
 
 export default {
   name: "LControlScale",
@@ -9,10 +9,15 @@ export default {
   setup(props, context) {
     const leafletRef = ref({});
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const registerControl = inject("registerControl");
+
     const { options, methods } = scaleControlSetup(props, leafletRef);
+
     onMounted(async () => {
-      const { control } = await import("leaflet/dist/leaflet-src.esm");
+      const { control } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = control.scale(options);
       propsBinder(methods, leafletRef.value, props);

--- a/src/components/LControlZoom.vue
+++ b/src/components/LControlZoom.vue
@@ -1,7 +1,7 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
 import { props, setup as zoomControlSetup } from "../functions/controlZoom";
-import { propsBinder } from "../utils.js";
+import { propsBinder, WINDOW_OR_GLOBAL, GLOBAL_LEAFLET_OPT } from "../utils.js";
 
 export default {
   name: "LControlZoom",
@@ -9,10 +9,15 @@ export default {
   setup(props, context) {
     const leafletRef = ref({});
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const registerControl = inject("registerControl");
+
     const { options, methods } = zoomControlSetup(props, leafletRef);
+
     onMounted(async () => {
-      const { control } = await import("leaflet/dist/leaflet-src.esm");
+      const { control } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = control.zoom(options);
       propsBinder(methods, leafletRef.value, props);

--- a/src/components/LFeatureGroup.vue
+++ b/src/components/LFeatureGroup.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as featureGroupSetup } from "../functions/featureGroup";
 import { render } from "../functions/layer";
 
@@ -10,14 +15,15 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { methods, options } = featureGroupSetup(props, leafletRef);
 
     onMounted(async () => {
-      const { featureGroup, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { featureGroup, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = featureGroup(options);
 

--- a/src/components/LGeoJson.vue
+++ b/src/components/LGeoJson.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as geoJSONSetup } from "../functions/geoJSON";
 import { render } from "../functions/layer";
 
@@ -10,14 +15,15 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { methods, options } = geoJSONSetup(props, leafletRef);
 
     onMounted(async () => {
-      const { geoJSON, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { geoJSON, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = geoJSON(props.geojson, options);
 

--- a/src/components/LGridLayer.vue
+++ b/src/components/LGridLayer.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, onUnmounted, ref, inject, nextTick, h, render } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import {
   props as gridLayerProps,
   setup as gridLayerSetup,
@@ -20,14 +25,15 @@ export default {
     const root = ref(null);
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = gridLayerSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { GridLayer, DomEvent, DomUtil } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { GridLayer, DomEvent, DomUtil } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       methods.onUnload = (e) => {
         const key = leafletRef.value._tileCoordsToKey(e.coords);

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick, h } from "vue";
-import { propsBinder, remapEvents } from "../utils";
+import {
+  propsBinder,
+  remapEvents,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils";
 import { props as iconProps } from "../functions/icon";
 import {
   props as componentProps,
@@ -19,6 +24,7 @@ export default {
   setup(props, context) {
     const root = ref(null);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const canSetParentHtml = inject("canSetParentHtml");
     const setParentHtml = inject("setParentHtml");
     const setIcon = inject("setIcon");
@@ -90,9 +96,9 @@ export default {
     };
 
     onMounted(async () => {
-      const { DomEvent, divIcon: lDivIcon, icon: lIcon } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { DomEvent, divIcon: lDivIcon, icon: lIcon } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       onDomEvent = DomEvent.on;
       offDomEvent = DomEvent.off;

--- a/src/components/LImageOverlay.vue
+++ b/src/components/LImageOverlay.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import {
   props as imageOverlayProps,
   setup as imageOverlaySetup,
@@ -17,14 +22,15 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = imageOverlaySetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { imageOverlay, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { imageOverlay, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
       leafletRef.value = imageOverlay(props.url, props.bounds, options);
 
       const listeners = remapEvents(context.attrs);

--- a/src/components/LLayerGroup.vue
+++ b/src/components/LLayerGroup.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as layerGroupSetup } from "../functions/layerGroup";
 import { render } from "../functions/layer";
 
@@ -10,14 +15,15 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { methods } = layerGroupSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { layerGroup, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { layerGroup, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
       leafletRef.value = layerGroup(props.options);
 
       const listeners = remapEvents(context.attrs);

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -1,6 +1,12 @@
 <script>
 import { onMounted, ref, provide, inject, nextTick } from "vue";
-import { remapEvents, propsBinder, debounce } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  debounce,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as markerSetup } from "../functions/marker";
 import { render } from "../functions/layer";
 
@@ -14,6 +20,7 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     provide("canSetParentHtml", () => !!leafletRef.value.getElement());
@@ -28,7 +35,9 @@ export default {
     const { options, methods } = markerSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { marker, DomEvent } = await import("leaflet/dist/leaflet-src.esm");
+      const { marker, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
       leafletRef.value = marker(props.latLng, options);
 
       const listeners = remapEvents(context.attrs);

--- a/src/components/LPolygon.vue
+++ b/src/components/LPolygon.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as polygonSetup } from "../functions/polygon";
 import { render } from "../functions/layer";
 
@@ -13,14 +18,16 @@ export default {
   setup(props, context) {
     const leafletRef = ref({});
     const ready = ref(false);
+
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = polygonSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { polygon, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { polygon, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = polygon(props.latLngs, options);
 

--- a/src/components/LPolyline.vue
+++ b/src/components/LPolyline.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as polylineSetup } from "../functions/polyline";
 import { render } from "../functions/layer";
 
@@ -14,14 +19,15 @@ export default {
     const leafletRef = ref({});
     const ready = ref(false);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = polylineSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { polyline, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { polyline, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = polyline(props.latLngs, options);
 

--- a/src/components/LPopup.vue
+++ b/src/components/LPopup.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { propsBinder, remapEvents } from "../utils.js";
+import {
+  propsBinder,
+  remapEvents,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as popupSetup } from "../functions/popup";
 import { render } from "../functions/popper";
 
@@ -14,11 +19,15 @@ export default {
     const leafletRef = ref({});
     const root = ref(null);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const bindPopup = inject("bindPopup");
+
     const { options, methods } = popupSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { popup, DomEvent } = await import("leaflet/dist/leaflet-src.esm");
+      const { popup, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = popup(options);
 

--- a/src/components/LRectangle.vue
+++ b/src/components/LRectangle.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as rectangleSetup } from "../functions/rectangle";
 import { render } from "../functions/layer";
 
@@ -13,14 +18,16 @@ export default {
   setup(props, context) {
     const leafletRef = ref({});
     const ready = ref(false);
+
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = rectangleSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { rectangle, latLngBounds, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { rectangle, latLngBounds, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       const bounds =
         props.bounds && props.bounds.length

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as tileLayerSetup } from "../functions/tileLayer";
 
 export default {
@@ -8,14 +13,15 @@ export default {
   setup(props, context) {
     const leafletRef = ref({});
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = tileLayerSetup(props, leafletRef);
 
     onMounted(async () => {
-      const { tileLayer, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { tileLayer, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
       leafletRef.value = tileLayer(props.url, options);
 
       const listeners = remapEvents(context.attrs);

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { propsBinder, remapEvents } from "../utils.js";
+import {
+  propsBinder,
+  remapEvents,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as tooltipSetup } from "../functions/tooltip";
 import { render } from "../functions/popper";
 
@@ -14,13 +19,15 @@ export default {
     const leafletRef = ref({});
     const root = ref(null);
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const bindTooltip = inject("bindTooltip");
+
     const { options, methods } = tooltipSetup(props, leafletRef, context);
 
     onMounted(async () => {
-      const { tooltip, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { tooltip, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = tooltip(options);
 

--- a/src/components/LWmsTileLayer.vue
+++ b/src/components/LWmsTileLayer.vue
@@ -1,6 +1,11 @@
 <script>
 import { onMounted, ref, inject, nextTick } from "vue";
-import { remapEvents, propsBinder } from "../utils.js";
+import {
+  remapEvents,
+  propsBinder,
+  WINDOW_OR_GLOBAL,
+  GLOBAL_LEAFLET_OPT,
+} from "../utils.js";
 import { props, setup as wmsLayerSetup } from "../functions/wmsTileLayer";
 
 export default {
@@ -8,14 +13,15 @@ export default {
   setup(props, context) {
     const leafletRef = ref({});
 
+    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const addLayer = inject("addLayer");
 
     const { options, methods } = wmsLayerSetup(props, leafletRef);
 
     onMounted(async () => {
-      const { tileLayer, DomEvent } = await import(
-        "leaflet/dist/leaflet-src.esm"
-      );
+      const { tileLayer, DomEvent } = useGlobalLeaflet
+        ? WINDOW_OR_GLOBAL.L
+        : await import("leaflet/dist/leaflet-src.esm");
 
       leafletRef.value = tileLayer.wms(props.baseUrl, options);
 

--- a/src/functions/component.js
+++ b/src/functions/component.js
@@ -1,7 +1,7 @@
 export const props = {
   options: {
     type: Object,
-    default: () => ({ useGlobalLeaflet: false }),
+    default: () => ({}),
   },
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -102,3 +102,10 @@ export const provideLeafletWrapper = (methodName) => {
  */
 export const updateLeafletWrapper = (wrapper, leafletMethod) =>
   (wrapper.wrapped.value = leafletMethod);
+
+export const WINDOW_OR_GLOBAL =
+  (typeof self === "object" && self.self === self && self) ||
+  (typeof global === "object" && global.global === global && global) ||
+  undefined;
+
+export const GLOBAL_LEAFLET_OPT = "useGlobalLeaflet";


### PR DESCRIPTION
The current implementation of the `useGlobalLeaflet` option is available independently on every component through the `options` prop defined in `component.js`, yet only the `LMap` component makes any use of it. This means that a map created using `window.L.map` will contain layers, markers, etc., created by methods imported from the Leaflet ESM, which leads to the same errors described in [the readme](https://github.com/vue-leaflet/vue-leaflet/blob/63f6e4070c0049b9025ec627d06fa3f8d47333e2/README.md#working-with-leaflet) when `useGlobalLeaflet` is false but additional components are imported directly from `"leaflet"`. In particular, #118 is caused by having `LMap` imported from `"leaflet"` and `LCircle` imported from `"leaflet/dist/leaflet-src.esm.js"`.

Additionally, the `options` object is supposed to contain Leaflet configuration options to be passed directly to the Leaflet component factory, whereas `useGlobalLeaflet` is a property specific to the vue-leaflet components and shouldn't be passed on. So configuring the vue-leaflet component via a property on the Leaflet options object seems potentially worth reworking even without the above problem it's causing.

This PR resolved that discrepancy and fixes #118 by moving `useGlobalLeaflet` to be a prop of the `LMap` component (and at the same time removing it as an option on all other components). The map then `provide`s the property value, and every remaining component `inject`s that value, and imports its Leaflet requirements from the same Leaflet instance that the map containing it used based on that.

## Breaking change
This does mean that there is a **breaking change** here, because `<l-map :options="{ useGlobalLeaflet: true }" ...>` will no longer have any effect. However, since the effect it used to have led to the inability to use some of the remaining map components and we are still in pre-release, I think the change to `<l-map :useGlobalLeaflet="true" ...>` is acceptable, and even beneficial. Happy to hear alternative suggestions though!

## Discussion
cc @schmic as the reporter of #118, and @juan267 who introduced the original fix to allow the global Leaflet instance to be used by plugins.

I've tested this with the `LCircle` component in the original issue report as well as with a third-party vanilla Leaflet library that relies on the existence of `window.L`. But I haven't checked it out in an SSR scenario, or with the Geoman plugin that originally motivated this fix in #35, for instance. If anyone is able to further test those, or identify any potential problems, please let us know any comments or concerns with this PR, whether it works for you, etc.