### PR TITLE
fix: remove icon option when undefined

### DIFF
--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -29,6 +29,12 @@ export default {
 
     onMounted(async () => {
       const { marker, DomEvent } = await import("leaflet/dist/leaflet-src.esm");
+      if (options.icon === undefined) {
+        // If the options objection has a property named 'icon', then Leaflet will overwrite
+        // the default icon with it for the marker, _even if it is undefined_.
+        // This leads to the issue discussed in https://github.com/vue-leaflet/vue-leaflet/issues/130
+        delete options.icon;
+      }
       leafletRef.value = marker(props.latLng, options);
 
       const listeners = remapEvents(context.attrs);

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -26,15 +26,15 @@ export default {
       (newIcon) => leafletRef.value.setIcon && leafletRef.value.setIcon(newIcon)
     );
     const { options, methods } = markerSetup(props, leafletRef, context);
+    if (options.icon === undefined) {
+      // If the options objection has a property named 'icon', then Leaflet will overwrite
+      // the default icon with it for the marker, _even if it is undefined_.
+      // This leads to the issue discussed in https://github.com/vue-leaflet/vue-leaflet/issues/130
+      delete options.icon;
+    }
 
     onMounted(async () => {
       const { marker, DomEvent } = await import("leaflet/dist/leaflet-src.esm");
-      if (options.icon === undefined) {
-        // If the options objection has a property named 'icon', then Leaflet will overwrite
-        // the default icon with it for the marker, _even if it is undefined_.
-        // This leads to the issue discussed in https://github.com/vue-leaflet/vue-leaflet/issues/130
-        delete options.icon;
-      }
       leafletRef.value = marker(props.latLng, options);
 
       const listeners = remapEvents(context.attrs);

--- a/src/functions/marker.js
+++ b/src/functions/marker.js
@@ -18,6 +18,7 @@ export const props = {
   },
   icon: {
     type: [Object],
+    default: () => undefined,
     custom: false,
   },
   zIndexOffset: {


### PR DESCRIPTION
Prevents Leaflet from overwriting the default marker icon with `undefined` and then trying to call `_initIcon` on that.

Resolves #130