### PR TITLE
Resolve 141 by ensuring expected functions can be called before using them

### DIFF
--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -98,19 +98,19 @@ export const setup = (props, leafletRef, context) => {
     },
     unbindTooltip() {
       const tooltip =
-        leafletRef.value && isFunction(leafletRef.value.unbindTooltip)
+        leafletRef.value && isFunction(leafletRef.value.getTooltip)
           ? leafletRef.value.getTooltip()
           : null;
-      if (tooltip) {
+      if (tooltip && isFunction(tooltip.unbindTooltip)) {
         tooltip.unbindTooltip();
       }
     },
     unbindPopup() {
       const popup =
-        leafletRef.value && isFunction(leafletRef.value.unbindPopup)
+        leafletRef.value && isFunction(leafletRef.value.getPopup)
           ? leafletRef.value.getPopup()
           : null;
-      if (popup) {
+      if (popup && isFunction(popup.unbindPopup)) {
         popup.unbindPopup();
       }
     },

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -1,5 +1,6 @@
 import { onUnmounted, provide, inject, h } from "vue";
 import { props as componentProps, setup as componentSetup } from "./component";
+import { isFunction } from "../utils";
 
 export const props = {
   ...componentProps,
@@ -74,19 +75,41 @@ export const setup = (props, leafletRef, context) => {
       }
     },
     bindPopup({ leafletObject }) {
+      if (!leafletRef.value || !isFunction(leafletRef.value.bindPopup)) {
+        console.warn(
+          "Attempt to bind popup before bindPopup method available on layer."
+        );
+
+        return;
+      }
+
       leafletRef.value.bindPopup(leafletObject);
     },
     bindTooltip({ leafletObject }) {
+      if (!leafletRef.value || !isFunction(leafletRef.value.bindTooltip)) {
+        console.warn(
+          "Attempt to bind tooltip before bindTooltip method available on layer."
+        );
+
+        return;
+      }
+
       leafletRef.value.bindTooltip(leafletObject);
     },
     unbindTooltip() {
-      const tooltip = leafletRef.value ? leafletRef.value.getTooltip() : null;
+      const tooltip =
+        leafletRef.value && isFunction(leafletRef.value.unbindTooltip)
+          ? leafletRef.value.getTooltip()
+          : null;
       if (tooltip) {
         tooltip.unbindTooltip();
       }
     },
     unbindPopup() {
-      const popup = leafletRef.value ? leafletRef.value.getPopup() : null;
+      const popup =
+        leafletRef.value && isFunction(leafletRef.value.unbindPopup)
+          ? leafletRef.value.getPopup()
+          : null;
       if (popup) {
         popup.unbindPopup();
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,7 +22,7 @@ export const capitalizeFirstLetter = (string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);
 };
 
-export const isFunction = (obj) => obj && typeof obj === "function";
+export const isFunction = (x) => typeof x === "function";
 
 export const propsBinder = (methods, leafletElement, props) => {
   for (const key in props) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,8 @@ export const capitalizeFirstLetter = (string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);
 };
 
+export const isFunction = (obj) => obj && typeof obj === "function";
+
 export const propsBinder = (methods, leafletElement, props) => {
   for (const key in props) {
     const setMethodName = "set" + capitalizeFirstLetter(key);


### PR DESCRIPTION
In #141 an edge case / race condition was identified when a layer component was created and destroyed in quick succession during mounting, which could result in the calling of methods that no longer existed during clean-up callbacks. This change simply checks to ensure that those functions exist as properties where they are expected, and if not then doesn't call them.

A warning is logged to the console if somehow the corresponding creation methods are called when the Leaflet objects or functions don't exist, because that is both unexpected and likely to lead to incorrect behaviour. I didn't add similar warnings during unmounting, because if the object isn't around, then the objective of removing it has been met, so it seems less likely to matter.