### PR TITLE
Adds zoomOffset to gridLayer.

### DIFF
--- a/src/functions/gridLayer.js
+++ b/src/functions/gridLayer.js
@@ -19,6 +19,10 @@ export const props = {
     type: Number,
     default: 256,
   },
+  zoomOffset: {
+    type: Number,
+    default: 0
+  },
   noWrap: {
     type: Boolean,
     default: false,
@@ -45,6 +49,7 @@ export const setup = (props, leafletRef, context) => {
     opacity: props.opacity,
     zIndex: props.zIndex,
     tileSize: props.tileSize,
+    zoomOffset: props.zoomOffset,
     noWrap: props.noWrap,
     minZoom: props.minZoom,
     maxZoom: props.maxZoom,


### PR DESCRIPTION
zoomOffset is needed to go along with tileSize. Note that this is untested but I haven't been able to install the npm package from my fork locally. I just get the following after running `npm install "git://github.com/conor-f/vue-leaflet.git#zoomOffset" --save`

```
* @vue-leaflet/vue-leaflet in ./node_modules/cache-loader/dist/cjs.js??ref--13-0!./node_modules/babel-loader/lib!./node_modules/cache-loader/dist/cjs.js??ref--1-0!./node_modules/vue-loader-v16/dist??ref--1-1!./src/components/ViaMap.vue?vue&type=script&lang=js
```

