### PR TITLE
Remove esm import and make mounted hook synchronous

### DIFF
--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -1,16 +1,12 @@
 <script>
 import { onMounted, ref, inject, nextTick, h } from "vue";
-import {
-  propsBinder,
-  remapEvents,
-  WINDOW_OR_GLOBAL,
-  GLOBAL_LEAFLET_OPT,
-} from "../utils";
+import { propsBinder, remapEvents } from "../utils";
 import { props as iconProps } from "../functions/icon";
 import {
   props as componentProps,
   setup as componentSetup,
 } from "../functions/component";
+import { DomEvent, divIcon as lDivIcon, icon as lIcon } from "leaflet";
 
 /**
  * Icon component, lets you add and custom icons to the map
@@ -24,7 +20,6 @@ export default {
   setup(props, context) {
     const root = ref(null);
 
-    const useGlobalLeaflet = inject(GLOBAL_LEAFLET_OPT);
     const canSetParentHtml = inject("canSetParentHtml");
     const setParentHtml = inject("setParentHtml");
     const setIcon = inject("setIcon");
@@ -94,12 +89,7 @@ export default {
       setClassName: scheduleCreateIcon,
       setHtml: scheduleCreateIcon,
     };
-
-    onMounted(async () => {
-      const { DomEvent, divIcon: lDivIcon, icon: lIcon } = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
-
+    onMounted(() => {
       onDomEvent = DomEvent.on;
       offDomEvent = DomEvent.off;
       divIcon = lDivIcon;


### PR DESCRIPTION
This PR addresses [issue 170](https://github.com/vue-leaflet/vue-leaflet/issues/170).

My hypothesis behind the change: We passed in an async functionIn the original code's `onMounted` hook. During the time before the `await import` resolves, `scheduleCreateIcon` does not get called, but the vue execution continues as if no slot content is passed in. Thus, it defaults to showing the default icon. The '#' slot content only begins to replace the default icons after the awaited promise resolves.

Using the change in this PR, I ran the app several times, spammed the toggle, and never experienced the blinking icons again. (I know that's not super scientific)
Reverting the change brought the blinking icons issue back. That suggests to me that the async nature of the mounted hook is the cause of the flicker.

This begs a couple questions: 
```
useGlobalLeaflet
        ? WINDOW_OR_GLOBAL.L
        : await import("leaflet/dist/leaflet-src.esm");
```

1. Why have the `useGlobalLeaflet` boolean?
2. Why use the `await import("...")`
3. Could we do away with them to fix the bug in question?

PS. I used this nifty tool called replay to help me debug a recording of the issue. https://app.replay.io/recording/178080be-b12e-4a20-8650-cf9547ddf1bf
Feel free to set a breakpoint in where I left a comment to better understand the issue.
If that tool is too much of a side-quest, then you could probably use a local debugger breakpoint inside the `scheduleCreateIcon` function in the LIcon.vue file to get the similar setup.