### PR TITLE
Fix 165

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -182,12 +182,8 @@ export default {
       markerZoomAnimation: props.markerZoomAnimation,
     };
 
-    const getAttributionControl = () => blueprint.leafletRef.attributionControl;
-
     const addLayer = provideLeafletWrapper("addLayer");
     const removeLayer = provideLeafletWrapper("removeLayer");
-    const addAttribution = provideLeafletWrapper("addAttribution");
-    const removeAttribution = provideLeafletWrapper("removeAttribution");
     const registerControl = provideLeafletWrapper("registerControl");
     const registerLayerControl = provideLeafletWrapper("registerLayerControl");
     provide(GLOBAL_LEAFLET_OPT, props.useGlobalLeaflet);
@@ -372,22 +368,10 @@ export default {
             });
           }
         },
-
-        addAttribution(attribution) {
-          const control = getAttributionControl();
-          control && control.addAttribution(attribution);
-        },
-
-        removeAttribution(attribution) {
-          const control = getAttributionControl();
-          control && control.removeAttribution(attribution);
-        },
       };
 
       updateLeafletWrapper(addLayer, methods.addLayer);
       updateLeafletWrapper(removeLayer, methods.removeLayer);
-      updateLeafletWrapper(addAttribution, methods.addAttribution);
-      updateLeafletWrapper(removeAttribution, methods.removeAttribution);
       updateLeafletWrapper(registerControl, methods.registerControl);
       updateLeafletWrapper(registerLayerControl, methods.registerLayerControl);
 

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -182,8 +182,12 @@ export default {
       markerZoomAnimation: props.markerZoomAnimation,
     };
 
+    const getAttributionControl = () => blueprint.leafletRef.attributionControl;
+
     const addLayer = provideLeafletWrapper("addLayer");
     const removeLayer = provideLeafletWrapper("removeLayer");
+    const addAttribution = provideLeafletWrapper("addAttribution");
+    const removeAttribution = provideLeafletWrapper("removeAttribution");
     const registerControl = provideLeafletWrapper("registerControl");
     const registerLayerControl = provideLeafletWrapper("registerLayerControl");
     provide(GLOBAL_LEAFLET_OPT, props.useGlobalLeaflet);
@@ -368,10 +372,22 @@ export default {
             });
           }
         },
+
+        addAttribution(attribution) {
+          const control = getAttributionControl();
+          control && control.addAttribution(attribution);
+        },
+
+        removeAttribution(attribution) {
+          const control = getAttributionControl();
+          control && control.removeAttribution(attribution);
+        },
       };
 
       updateLeafletWrapper(addLayer, methods.addLayer);
       updateLeafletWrapper(removeLayer, methods.removeLayer);
+      updateLeafletWrapper(addAttribution, methods.addAttribution);
+      updateLeafletWrapper(removeAttribution, methods.removeAttribution);
       updateLeafletWrapper(registerControl, methods.registerControl);
       updateLeafletWrapper(registerLayerControl, methods.registerLayerControl);
 

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -32,8 +32,6 @@ export const props = {
 export const setup = (props, leafletRef, context) => {
   const addLayer = inject("addLayer");
   const removeLayer = inject("removeLayer");
-  const addAttribution = inject("addAttribution");
-  const removeAttribution = inject("removeAttribution");
   const {
     options: componentOptions,
     methods: componentMethods,
@@ -51,9 +49,12 @@ export const setup = (props, leafletRef, context) => {
 
   const methods = {
     ...componentMethods,
-    setAttribution(val, old) {
-      removeAttribution(old);
-      addAttribution(val);
+    setAttribution(val) {
+      removeThisLayer();
+      leafletRef.value.options.attribution = val;
+      if (props.visible) {
+        addThisLayer();
+      }
     },
     setName() {
       removeThisLayer();

--- a/src/functions/layer.js
+++ b/src/functions/layer.js
@@ -32,6 +32,8 @@ export const props = {
 export const setup = (props, leafletRef, context) => {
   const addLayer = inject("addLayer");
   const removeLayer = inject("removeLayer");
+  const addAttribution = inject("addAttribution");
+  const removeAttribution = inject("removeAttribution");
   const {
     options: componentOptions,
     methods: componentMethods,
@@ -50,8 +52,8 @@ export const setup = (props, leafletRef, context) => {
   const methods = {
     ...componentMethods,
     setAttribution(val, old) {
-      const attributionControl = this.$parent.leafletObject.attributionControl;
-      attributionControl.removeAttribution(old).addAttribution(val);
+      removeAttribution(old);
+      addAttribution(val);
     },
     setName() {
       removeThisLayer();


### PR DESCRIPTION
Fixes #165. Since `this` is no longer equal to the Vue component in general under the composition API, trying to find the map's attribution control via `this.$parent` was throwing the error described in the issue.

I originally attempted to retain that logic that updated the map's attribution without removing and re-adding the layer, but this led to both the old and new attributions appearing on the map at the same time in some situations. If another prop, such as `name`, caused the layer to be removed and re-added, the original attribution still present in the layer's `leafletObject` options from when it was instantiated would be added back as well.

This fix simply removes the layer from the map, updates the attribution option on it, then adds it back, leaving Leaflet to take care of managing the state of the map's attribution control without ever needing access to it or the map from within the layer.