### PR TITLE
Check if $slots.default is defined before calling

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -408,7 +408,7 @@ export default {
     return h(
       "div",
       { style: { width: "100%", height: "100%" }, ref: "root" },
-      this.ready ? this.$slots.default() : {}
+      this.ready && this.$slots.default ? this.$slots.default() : {}
     );
   },
 };


### PR DESCRIPTION
I ran into this issue https://github.com/vue-leaflet/vue-leaflet/issues/138 today.

I found locally it was resolved by checking if `$slots.default` is defined before calling it. This is already done for the `LIcon` component, but not `LMap`.

I couldn't see any tests in the repo to try and create a test for it.