### PR TITLE
Proprosed fix for issue with Map bound not used on the map

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "module": "dist/vue-leaflet.esm.js",
   "files": [
     "dist/",
-    "src/"
+    "src/",
+    "rollup.config.js",
+    "vue.config.js"
   ],
   "repository": {
     "type": "git",

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -376,6 +376,9 @@ export default {
       updateLeafletWrapper(registerLayerControl, methods.registerLayerControl);
 
       blueprint.leafletRef = map(root.value, options);
+      if (this.bounds) {
+          blueprint.leafletRef.fitBounds(this.bounds);
+      }
 
       propsBinder(methods, blueprint.leafletRef, props);
       const listeners = remapEvents(context.attrs);

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -371,7 +371,13 @@ export default {
 
       blueprint.leafletRef = map(root.value, options);
       if (props.bounds) {
-        blueprint.leafletRef.fitBounds(props.bounds);
+        // Need to do this because there seems to be a prototype conflict even if we use
+        // the same version/method to create the LatLngBounds object
+        const newBounds = latLngBounds(
+          props.bounds._northEast,
+          props.bounds._southWest
+        );
+        blueprint.leafletRef.fitBounds(newBounds);
       }
 
       propsBinder(methods, blueprint.leafletRef, props);

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -225,16 +225,10 @@ export default {
       if (props.useGlobalLeaflet) {
         WINDOW_OR_GLOBAL.L = WINDOW_OR_GLOBAL.L || (await import("leaflet"));
       }
-      const {
-        map,
-        CRS,
-        Icon,
-        latLngBounds,
-        latLng,
-        DomEvent,
-      } = props.useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { map, CRS, Icon, latLngBounds, latLng, DomEvent } =
+        props.useGlobalLeaflet
+          ? WINDOW_OR_GLOBAL.L
+          : await import("leaflet/dist/leaflet-src.esm");
 
       try {
         options.beforeMapMount && (await options.beforeMapMount());
@@ -376,8 +370,8 @@ export default {
       updateLeafletWrapper(registerLayerControl, methods.registerLayerControl);
 
       blueprint.leafletRef = map(root.value, options);
-      if (this.bounds) {
-          blueprint.leafletRef.fitBounds(this.bounds);
+      if (props.bounds) {
+        blueprint.leafletRef.fitBounds(props.bounds);
       }
 
       propsBinder(methods, blueprint.leafletRef, props);


### PR DESCRIPTION
Following the issue https://github.com/vue-leaflet/vue-leaflet/issues/224, I need to have it working for our application to avoid regression. So this is a suggestion to have it working.

I encountered an issue with `latLngBounds` was not recognizing the object as a `LatLngBounds`. It seems similar to the https://github.com/vue-leaflet/vue-leaflet/issues/48. I temporarily fixed it but not sure if you want to have a look at it.

I was force to exposed more files since it didn't expose the build, which prevent the build of the fork.