### PR TITLE
markRaw leaflet map instance to prevent deep conversion to proxies

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -2,6 +2,7 @@
 import {
   computed,
   h,
+  markRaw,
   nextTick,
   onBeforeUnmount,
   onMounted,
@@ -375,7 +376,7 @@ export default {
       updateLeafletWrapper(registerControl, methods.registerControl);
       updateLeafletWrapper(registerLayerControl, methods.registerLayerControl);
 
-      blueprint.leafletRef = map(root.value, options);
+      blueprint.leafletRef = markRaw(map(root.value, options));
 
       propsBinder(methods, blueprint.leafletRef, props);
       const listeners = remapEvents(context.attrs);


### PR DESCRIPTION
A fix for https://github.com/vue-leaflet/vue-leaflet/issues/100 although more things should be markRaw'd to make sure this doesn't happen in other places and to improve performance. 