### PR TITLE
Correct LTileLayer subdomains prop type from String to [Array, String].

### DIFF
--- a/src/functions/tileLayer.js
+++ b/src/functions/tileLayer.js
@@ -8,7 +8,7 @@ export const tileLayerProps = {
     default: undefined,
   },
   subdomains: {
-    type: String,
+    type: [Array, String],
   },
   detectRetina: {
     type: Boolean,


### PR DESCRIPTION
Currently prop type of String generates annoying warning. As per doc TileLayer subdomains option can be a String or an Array -- https://leafletjs.com/reference.html#tilelayer, https://vue2-leaflet.netlify.app/components/LTileLayer.html#props