### PR TITLE
Remove unused DOMEvent

### DIFF
--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -156,6 +156,7 @@ const mapProps = {
 };
 
 export default defineComponent({
+  inheritAttrs: false,
   emits: ["ready", "update:zoom", "update:center", "update:bounds"],
   props: mapProps,
   setup(props, context) {
@@ -251,7 +252,6 @@ export default defineComponent({
         Icon,
         latLngBounds,
         latLng,
-        DomEvent,
         stamp,
       }: typeof L = props.useGlobalLeaflet
         ? WINDOW_OR_GLOBAL.L
@@ -387,7 +387,7 @@ export default defineComponent({
       const listeners: any = remapEvents(context.attrs); // TODO: proper typing
 
       bindEventHandlers(blueprint.leafletRef, eventHandlers);
-      DomEvent.on(blueprint.leafletRef.getContainer(), listeners);
+      bindEventHandlers(blueprint.leafletRef, listeners);
       blueprint.ready = true;
       nextTick(() => context.emit("ready", blueprint.leafletRef));
     });


### PR DESCRIPTION
At least click and dblclick event-handlers for LMap seems to be broken, with two generic MouseEvents fired instead of one MouseEvent provided by Leaflet. As such, both of these events lacks lat-long coordinates, as also mentioned here: https://github.com/vue-leaflet/vue-leaflet/issues/287

I found two reasons for the behavior:
1. Leaflet-event handlers are not documented in props or emits, and are as such gathered to context.attrs. By default Vue attaches these to the root element (div in this case). This causes the double events, as there are two handlers attached. I prevented the attribute inheritance in LMap.
** If some styling etc relies on attribute forwarding this fix will break these. In this case the extracted event-handlers should rather be removed from the context.
3. Events are attached to the Leaflet-object instead of container. This wraps the generic MouseEvent with the Leaflet-event, which includes f.ex. the lat-long coordinates.
** Again, if some non-documented props/events should be attached to the container, this change will break these.

With these, I am seeing a single Leaflet event fired when clicking on the map.
![image](https://user-images.githubusercontent.com/2345041/235151203-3867e6a1-3e4e-43be-a2d2-2e9320874f1b.png)

Referencing issue: https://github.com/vue-leaflet/vue-leaflet/issues/287, I run into similar problems. 