### PR TITLE
feat: added utils export

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,3 +1,4 @@
 export * from "./components";
 export * as InjectionKeys from "./types/injectionKeys";
 export * as Functions from "./functions";
+export * as Utils from "./utils";


### PR DESCRIPTION
As stated in [PR-313](https://github.com/vue-leaflet/vue-leaflet/pull/313) I'm currently creating a markercluster extension for this lib. While the creation process I realized that my last PR was incomplete. I missed to export the utils file, which currently leads in my repository to a duplication of this file.

This PR should fix this.

@mikeu Would be awesome if we could merge this before the next release (Damn I see you released 6 hours ago 🙈 )