### PR TITLE
Use global leaflet refactor

### DIFF
--- a/src/components/LCircle.vue
+++ b/src/components/LCircle.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { circleProps, setupCircle } from "@src/functions/circle";
 import { render } from "@src/functions/layer";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -32,16 +22,12 @@ export default defineComponent({
     const leafletObject = ref<L.Circle>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupCircle(props, leafletObject, context);
 
     onMounted(async () => {
-      const { circle }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
-
+      const { circle }: typeof L = await getLeaflet();
       leafletObject.value = markRaw<L.Circle>(circle(props.latLng, options));
 
       const { listeners } = remapEvents(context.attrs);

--- a/src/components/LCircleMarker.vue
+++ b/src/components/LCircleMarker.vue
@@ -1,26 +1,16 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import {
   circleMarkerProps,
   setupCircleMarker,
 } from "@src/functions/circleMarker";
 import { render } from "@src/functions/layer";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -35,7 +25,6 @@ export default defineComponent({
     const leafletObject = ref<L.CircleMarker>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupCircleMarker(
@@ -45,9 +34,7 @@ export default defineComponent({
     );
 
     onMounted(async () => {
-      const { circleMarker }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { circleMarker }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.CircleMarker>(
         circleMarker(props.latLng, options)

--- a/src/components/LControl.vue
+++ b/src/components/LControl.vue
@@ -1,24 +1,14 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import {
   controlProps,
   renderLControl,
   setupControl,
 } from "@src/functions/control";
-import {
-  RegisterControlInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import { WINDOW_OR_GLOBAL, assertInject, propsBinder } from "@src/utils.js";
+import { RegisterControlInjection } from "@src/types/injectionKeys";
+import { assertInject, getLeaflet, propsBinder } from "@src/utils.js";
 
 export default defineComponent({
   name: "LControl",
@@ -39,15 +29,12 @@ export default defineComponent({
     const leafletObject = ref<L.Control>();
     const root = ref<HTMLInputElement>();
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const registerControl = assertInject(RegisterControlInjection);
 
     const { options, methods } = setupControl(props, leafletObject);
 
     onMounted(async () => {
-      const { Control, DomEvent }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { Control, DomEvent }: typeof L = await getLeaflet();
 
       const LControl = Control.extend({
         onAdd() {

--- a/src/components/LControlAttribution.vue
+++ b/src/components/LControlAttribution.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import {
   controlAttributionProps,
   setupControlAttribution,
 } from "@src/functions/controlAttribution";
-import {
-  RegisterControlInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import { WINDOW_OR_GLOBAL, assertInject, propsBinder } from "@src/utils.js";
+import { RegisterControlInjection } from "@src/types/injectionKeys";
+import { assertInject, getLeaflet, propsBinder } from "@src/utils.js";
 
 export default defineComponent({
   name: "LControlAttribution",
@@ -25,15 +15,12 @@ export default defineComponent({
   setup(props, context) {
     const leafletObject = ref<L.Control.Attribution>();
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const registerControl = assertInject(RegisterControlInjection);
 
     const { options, methods } = setupControlAttribution(props, leafletObject);
 
     onMounted(async () => {
-      const { control }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { control }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.Control.Attribution>(
         control.attribution(options)

--- a/src/components/LControlLayers.vue
+++ b/src/components/LControlLayers.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import {
   controlLayersProps,
   setupControlLayers,
 } from "@src/functions/controlLayers";
-import {
-  RegisterLayerControlInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import { WINDOW_OR_GLOBAL, assertInject, propsBinder } from "@src/utils.js";
+import { RegisterLayerControlInjection } from "@src/types/injectionKeys";
+import { assertInject, getLeaflet, propsBinder } from "@src/utils.js";
 
 export default defineComponent({
   name: "LControlLayers",
@@ -25,16 +15,12 @@ export default defineComponent({
   setup(props, context) {
     const leafletObject = ref<L.Control.Layers>();
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const registerLayerControl = assertInject(RegisterLayerControlInjection);
 
     const { options, methods } = setupControlLayers(props, leafletObject);
 
     onMounted(async () => {
-      const { control }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
-
+      const { control }: typeof L = await getLeaflet();
       leafletObject.value = markRaw<L.Control.Layers>(
         control.layers(undefined, undefined, options)
       );

--- a/src/components/LControlScale.vue
+++ b/src/components/LControlScale.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import {
   controlScaleProps,
   setupControlScale,
 } from "@src/functions/controlScale";
-import {
-  RegisterControlInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import { WINDOW_OR_GLOBAL, assertInject, propsBinder } from "@src/utils.js";
+import { RegisterControlInjection } from "@src/types/injectionKeys";
+import { assertInject, getLeaflet, propsBinder } from "@src/utils.js";
 
 export default defineComponent({
   name: "LControlScale",
@@ -25,16 +15,12 @@ export default defineComponent({
   setup(props, context) {
     const leafletObject = ref<L.Control.Scale>();
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const registerControl = assertInject(RegisterControlInjection);
 
     const { options, methods } = setupControlScale(props, leafletObject);
 
     onMounted(async () => {
-      const { control }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
-
+      const { control }: typeof L = await getLeaflet();
       leafletObject.value = markRaw<L.Control.Scale>(control.scale(options));
       propsBinder(methods, leafletObject.value, props);
       registerControl({ leafletObject: leafletObject.value });

--- a/src/components/LControlZoom.vue
+++ b/src/components/LControlZoom.vue
@@ -1,20 +1,10 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { controlZoomProps, setupControlZoom } from "@src/functions/controlZoom";
-import {
-  RegisterControlInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import { WINDOW_OR_GLOBAL, assertInject, propsBinder } from "@src/utils.js";
+import { RegisterControlInjection } from "@src/types/injectionKeys";
+import { assertInject, getLeaflet, propsBinder } from "@src/utils.js";
 
 export default defineComponent({
   name: "LControlZoom",
@@ -22,15 +12,12 @@ export default defineComponent({
   setup(props, context) {
     const leafletObject = ref<L.Control.Scale>();
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const registerControl = assertInject(RegisterControlInjection);
 
     const { options, methods } = setupControlZoom(props, leafletObject);
 
     onMounted(async () => {
-      const { control }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { control }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.Control.Scale>(control.zoom(options));
       propsBinder(methods, leafletObject.value, props);

--- a/src/components/LFeatureGroup.vue
+++ b/src/components/LFeatureGroup.vue
@@ -1,26 +1,16 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import {
   featureGroupProps,
   setupFeatureGroup,
 } from "@src/functions/featureGroup";
 import { render } from "@src/functions/layer";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -31,7 +21,6 @@ export default defineComponent({
     const leafletObject = ref<L.FeatureGroup>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { methods, options } = setupFeatureGroup(
@@ -41,9 +30,7 @@ export default defineComponent({
     );
 
     onMounted(async () => {
-      const { featureGroup }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { featureGroup }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.FeatureGroup>(
         featureGroup(undefined, options)

--- a/src/components/LGeoJson.vue
+++ b/src/components/LGeoJson.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { geoJSONProps, setupGeoJSON } from "@src/functions/geoJSON";
 import { render } from "@src/functions/layer";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -28,15 +18,12 @@ export default defineComponent({
     const leafletObject = ref<L.GeoJSON>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { methods, options } = setupGeoJSON(props, leafletObject, context);
 
     onMounted(async () => {
-      const { geoJSON }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { geoJSON }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.GeoJSON>(geoJSON(props.geojson, options));
 

--- a/src/components/LGridLayer.vue
+++ b/src/components/LGridLayer.vue
@@ -4,7 +4,6 @@ import {
   type PropType,
   defineComponent,
   h,
-  inject,
   markRaw,
   nextTick,
   onMounted,
@@ -17,13 +16,10 @@ import {
   gridLayerProps,
   setupGridLayer,
 } from "@src/functions/gridLayer";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -41,15 +37,12 @@ export default defineComponent({
     const root = ref(null);
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupGridLayer(props, leafletObject, context);
 
     onMounted(async () => {
-      const { GridLayer, DomUtil, Util }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { GridLayer, DomUtil, Util }: typeof L = await getLeaflet();
 
       const GLayer = CreateVueGridLayer(
         GridLayer,

--- a/src/components/LIcon.vue
+++ b/src/components/LIcon.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type L from "leaflet";
-import { defineComponent, h, inject, nextTick, onMounted, ref } from "vue";
+import { defineComponent, h, nextTick, onMounted, ref } from "vue";
 
 import { componentProps, setupComponent } from "@src/functions/component";
 import { iconProps } from "@src/functions/icon";
@@ -8,11 +8,10 @@ import {
   CanSetParentHtmlInjection,
   SetIconInjection,
   SetParentHtmlInjection,
-  UseGlobalLeafletInjection,
 } from "@src/types/injectionKeys";
 import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   propsToLeafletOptions,
   remapEvents,
@@ -30,7 +29,6 @@ export default defineComponent({
   setup(props, context) {
     const root = ref<HTMLInputElement>();
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const canSetParentHtml = assertInject(CanSetParentHtmlInjection);
     const setParentHtml = assertInject(SetParentHtmlInjection);
     const setIcon = assertInject(SetIconInjection);
@@ -98,9 +96,7 @@ export default defineComponent({
         DomEvent,
         divIcon: lDivIcon,
         icon: lIcon,
-      }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      }: typeof L = await getLeaflet();
 
       onDomEvent = DomEvent.on;
       offDomEvent = DomEvent.off;

--- a/src/components/LImageOverlay.vue
+++ b/src/components/LImageOverlay.vue
@@ -1,26 +1,16 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import {
   imageOverlayProps,
   setupImageOverlay,
 } from "@src/functions/imageOverlay";
 import { render } from "@src/functions/layer";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -35,7 +25,6 @@ export default defineComponent({
     const leafletObject = ref<L.ImageOverlay>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupImageOverlay(
@@ -45,9 +34,7 @@ export default defineComponent({
     );
 
     onMounted(async () => {
-      const { imageOverlay }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { imageOverlay }: typeof L = await getLeaflet();
       leafletObject.value = markRaw<L.ImageOverlay>(
         imageOverlay(props.url, props.bounds, options)
       );

--- a/src/components/LLayerGroup.vue
+++ b/src/components/LLayerGroup.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { render } from "@src/functions/layer";
 import { layerGroupProps, setupLayerGroup } from "@src/functions/layerGroup";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -28,15 +18,12 @@ export default defineComponent({
     const leafletObject = ref<L.LayerGroup>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { methods } = setupLayerGroup(props, leafletObject, context);
 
     onMounted(async () => {
-      const { layerGroup }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { layerGroup }: typeof L = await getLeaflet();
       leafletObject.value = markRaw<L.LayerGroup>(
         layerGroup(undefined, props.options)
       );

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -10,7 +10,6 @@ import {
   nextTick,
   onBeforeUnmount,
   onMounted,
-  provide,
   reactive,
   ref,
 } from "vue";
@@ -18,7 +17,6 @@ import {
 import { componentProps, setupComponent } from "@src/functions/component";
 import {
   AddLayerInjection,
-  LeafletPromiseInjection,
   RegisterControlInjection,
   RegisterLayerControlInjection,
   RemoveLayerInjection,
@@ -186,7 +184,8 @@ export default defineComponent({
       RegisterLayerControlInjection
     );
 
-    provide(LeafletPromiseInjection, getLeaflet(props.useGlobalLeaflet));
+    // Ensures leaflet module ref used by all components is initialized as early as possible.
+    getLeaflet(props.useGlobalLeaflet);
 
     const zoomPanOptions = computed(() => {
       const result: L.ZoomPanOptions = {};

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -18,10 +18,10 @@ import {
 import { componentProps, setupComponent } from "@src/functions/component";
 import {
   AddLayerInjection,
+  LeafletPromiseInjection,
   RegisterControlInjection,
   RegisterLayerControlInjection,
   RemoveLayerInjection,
-  UseGlobalLeafletInjection,
 } from "@src/types/injectionKeys";
 import type {
   IControlDefinition,
@@ -31,9 +31,9 @@ import type {
 } from "@src/types/interfaces";
 import {
   type Data,
-  WINDOW_OR_GLOBAL,
   bindEventHandlers,
   cancelDebounces,
+  getLeaflet,
   propsBinder,
   propsToLeafletOptions,
   provideLeafletWrapper,
@@ -185,7 +185,8 @@ export default defineComponent({
     const registerLayerControl = provideLeafletWrapper(
       RegisterLayerControlInjection
     );
-    provide(UseGlobalLeafletInjection, props.useGlobalLeaflet);
+
+    provide(LeafletPromiseInjection, getLeaflet(props.useGlobalLeaflet));
 
     const zoomPanOptions = computed(() => {
       const result: L.ZoomPanOptions = {};
@@ -247,14 +248,8 @@ export default defineComponent({
     };
 
     onMounted(async () => {
-      if (props.useGlobalLeaflet) {
-        WINDOW_OR_GLOBAL.L = WINDOW_OR_GLOBAL.L || (await import("leaflet"));
-      }
-      const { map, CRS, Icon, latLngBounds, latLng, stamp }: typeof L =
-        props.useGlobalLeaflet
-          ? WINDOW_OR_GLOBAL.L
-          : await import("leaflet/dist/leaflet-src.esm");
-
+      const leaflet: typeof L = await getLeaflet();
+      const { map, CRS, Icon, latLngBounds, latLng, stamp } = leaflet;
       try {
         // TODO: Is beforeMapMount still needed?
         options.beforeMapMount && (await options.beforeMapMount());

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -3,7 +3,6 @@ import type L from "leaflet";
 import { debounce } from "ts-debounce";
 import {
   defineComponent,
-  inject,
   markRaw,
   nextTick,
   onBeforeUnmount,
@@ -23,12 +22,11 @@ import {
   CanSetParentHtmlInjection,
   SetIconInjection,
   SetParentHtmlInjection,
-  UseGlobalLeafletInjection,
 } from "@src/types/injectionKeys";
 import {
-  WINDOW_OR_GLOBAL,
   assertInject,
   cancelDebounces,
+  getLeaflet,
   isFunction,
   propsBinder,
   remapEvents,
@@ -44,7 +42,6 @@ export default defineComponent({
     const leafletObject = ref<L.Marker>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     provide(
@@ -70,9 +67,7 @@ export default defineComponent({
     };
 
     onMounted(async () => {
-      const { marker, divIcon }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { marker, divIcon }: typeof L = await getLeaflet();
 
       if (shouldBlankIcon(options, context)) {
         options.icon = divIcon({ className: "" });

--- a/src/components/LPolygon.vue
+++ b/src/components/LPolygon.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { render } from "@src/functions/layer";
 import { polygonProps, setupPolygon } from "@src/functions/polygon";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -32,15 +22,12 @@ export default defineComponent({
     const leafletObject = ref<L.Polygon>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupPolygon(props, leafletObject, context);
 
     onMounted(async () => {
-      const { polygon }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { polygon }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.Polygon>(polygon(props.latLngs, options));
 

--- a/src/components/LPolyline.vue
+++ b/src/components/LPolyline.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { render } from "@src/functions/layer";
 import { polylineProps, setupPolyline } from "@src/functions/polyline";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -32,15 +22,12 @@ export default defineComponent({
     const leafletObject = ref<L.Polyline>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupPolyline(props, leafletObject, context);
 
     onMounted(async () => {
-      const { polyline }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { polyline }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.Polyline>(
         polyline(props.latLngs, options)

--- a/src/components/LPopup.vue
+++ b/src/components/LPopup.vue
@@ -2,7 +2,6 @@
 import type L from "leaflet";
 import {
   defineComponent,
-  inject,
   markRaw,
   nextTick,
   onBeforeUnmount,
@@ -15,11 +14,10 @@ import { popupProps, setupPopup } from "@src/functions/popup";
 import {
   BindPopupInjection,
   UnbindPopupInjection,
-  UseGlobalLeafletInjection,
 } from "@src/types/injectionKeys";
 import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -34,16 +32,13 @@ export default defineComponent({
     const leafletObject = ref<L.Popup>();
     const root = ref(null);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const bindPopup = assertInject(BindPopupInjection);
     const unbindPopup = assertInject(UnbindPopupInjection);
 
     const { options, methods } = setupPopup(props, leafletObject);
 
     onMounted(async () => {
-      const { popup }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { popup }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.Popup>(popup(options));
 

--- a/src/components/LRectangle.vue
+++ b/src/components/LRectangle.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { render } from "@src/functions/layer";
 import { rectangleProps, setupRectangle } from "@src/functions/rectangle";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -32,15 +22,12 @@ export default defineComponent({
     const leafletObject = ref<L.Rectangle>();
     const ready = ref(false);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupRectangle(props, leafletObject, context);
 
     onMounted(async () => {
-      const { rectangle, latLngBounds }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { rectangle, latLngBounds }: typeof L = await getLeaflet();
 
       const bounds = props.bounds
         ? latLngBounds(props.bounds)

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -1,22 +1,12 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { setupTileLayer, tileLayerProps } from "@src/functions/tileLayer";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -26,15 +16,12 @@ export default defineComponent({
   setup(props, context) {
     const leafletObject = ref<L.TileLayer>();
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupTileLayer(props, leafletObject, context);
 
     onMounted(async () => {
-      const { tileLayer }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { tileLayer }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.TileLayer>(tileLayer(props.url, options));
 

--- a/src/components/LTooltip.vue
+++ b/src/components/LTooltip.vue
@@ -1,23 +1,13 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import { render } from "@src/functions/popper";
 import { setupTooltip, tooltipProps } from "@src/functions/tooltip";
+import { BindTooltipInjection } from "@src/types/injectionKeys";
 import {
-  BindTooltipInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -32,16 +22,12 @@ export default defineComponent({
     const leafletObject = ref<L.Tooltip>();
     const root = ref(null);
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const bindTooltip = assertInject(BindTooltipInjection);
 
     const { options, methods } = setupTooltip(props, leafletObject);
 
     onMounted(async () => {
-      const { tooltip }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
-
+      const { tooltip }: typeof L = await getLeaflet();
       leafletObject.value = markRaw<L.Tooltip>(tooltip(options));
 
       propsBinder(methods, leafletObject.value, props);

--- a/src/components/LWmsTileLayer.vue
+++ b/src/components/LWmsTileLayer.vue
@@ -1,25 +1,15 @@
 <script lang="ts">
 import type L from "leaflet";
-import {
-  defineComponent,
-  inject,
-  markRaw,
-  nextTick,
-  onMounted,
-  ref,
-} from "vue";
+import { defineComponent, markRaw, nextTick, onMounted, ref } from "vue";
 
 import {
   setupWMSTileLayer,
   wmsTileLayerProps,
 } from "@src/functions/wmsTileLayer";
+import { AddLayerInjection } from "@src/types/injectionKeys";
 import {
-  AddLayerInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
-import {
-  WINDOW_OR_GLOBAL,
   assertInject,
+  getLeaflet,
   propsBinder,
   remapEvents,
 } from "@src/utils.js";
@@ -29,7 +19,6 @@ export default defineComponent({
   setup(props, context) {
     const leafletObject = ref<L.TileLayer.WMS>();
 
-    const useGlobalLeaflet = inject(UseGlobalLeafletInjection);
     const addLayer = assertInject(AddLayerInjection);
 
     const { options, methods } = setupWMSTileLayer(
@@ -39,9 +28,7 @@ export default defineComponent({
     );
 
     onMounted(async () => {
-      const { tileLayer }: typeof L = useGlobalLeaflet
-        ? WINDOW_OR_GLOBAL.L
-        : await import("leaflet/dist/leaflet-src.esm");
+      const { tileLayer }: typeof L = await getLeaflet();
 
       leafletObject.value = markRaw<L.TileLayer.WMS>(
         tileLayer.wms(props.url, options)

--- a/src/types/injectionKeys.ts
+++ b/src/types/injectionKeys.ts
@@ -3,9 +3,9 @@ import type { InjectionKey } from "vue";
 
 import type { IControlDefinition, ILayerDefinition } from "./interfaces";
 
-export const UseGlobalLeafletInjection = Symbol(
-  "useGlobalLeaflet"
-) as InjectionKey<boolean>;
+export const LeafletPromiseInjection = Symbol("leafletPromise") as InjectionKey<
+  Promise<typeof L>
+>;
 
 export const AddLayerInjection = Symbol("addLayer") as InjectionKey<
   (layer: ILayerDefinition) => void

--- a/src/types/injectionKeys.ts
+++ b/src/types/injectionKeys.ts
@@ -3,10 +3,6 @@ import type { InjectionKey } from "vue";
 
 import type { IControlDefinition, ILayerDefinition } from "./interfaces";
 
-export const LeafletPromiseInjection = Symbol("leafletPromise") as InjectionKey<
-  Promise<typeof L>
->;
-
 export const AddLayerInjection = Symbol("addLayer") as InjectionKey<
   (layer: ILayerDefinition) => void
 >;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,3 +155,17 @@ export const assertInject = <T>(key: InjectionKey<T>) => {
 
   return value;
 };
+
+let leafletPromise: Promise<typeof L> | undefined;
+
+export const getLeaflet = (useGlobalLeaflet = true) => {
+  if (leafletPromise) return leafletPromise;
+  if (useGlobalLeaflet) {
+    leafletPromise = WINDOW_OR_GLOBAL.L
+      ? Promise.resolve(WINDOW_OR_GLOBAL.L)
+      : import("leaflet");
+  } else {
+    leafletPromise = import("leaflet/dist/leaflet-src.esm");
+  }
+  return leafletPromise;
+};

--- a/tests/unit/components/LControlAttribution.test.ts
+++ b/tests/unit/components/LControlAttribution.test.ts
@@ -3,14 +3,11 @@ import "leaflet";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import LControlAttribution from "@src/components/LControlAttribution.vue";
-import {
-  RegisterControlInjection,
-  UseGlobalLeafletInjection,
-} from "@src/types/injectionKeys";
+import { RegisterControlInjection } from "@src/types/injectionKeys";
 
-describe.each([true, false])("LControlAttribution", (useGlobalLeaflet) => {
+describe.each([true, false])("LControlAttribution", () => {
   const mockRegisterControl = vi.fn();
-  const getWrapper = async (shouldUseL) => {
+  const getWrapper = async () => {
     const wrapper = shallowMount(LControlAttribution, {
       propsData: {
         position: "topright",
@@ -18,7 +15,6 @@ describe.each([true, false])("LControlAttribution", (useGlobalLeaflet) => {
       },
       global: {
         provide: {
-          [UseGlobalLeafletInjection as symbol]: () => shouldUseL,
           [RegisterControlInjection as symbol]: mockRegisterControl,
         },
       },
@@ -32,8 +28,8 @@ describe.each([true, false])("LControlAttribution", (useGlobalLeaflet) => {
     mockRegisterControl.mockReset();
   });
 
-  it(`emits a ready event with the Leaflet object, with useGlobalLeaflet ${useGlobalLeaflet}`, async () => {
-    const wrapper = await getWrapper(useGlobalLeaflet);
+  it(`emits a ready event with the Leaflet object`, async () => {
+    const wrapper = await getWrapper();
 
     expect(wrapper.emitted()).to.have.property("ready");
     const readyEvent = wrapper.emitted("ready");
@@ -41,8 +37,8 @@ describe.each([true, false])("LControlAttribution", (useGlobalLeaflet) => {
     expect(readyEvent![0]).to.deep.equal([wrapper.vm.leafletObject]);
   });
 
-  it(`creates a Leaflet object with expected properties, with useGlobalLeaflet ${useGlobalLeaflet}`, async () => {
-    const wrapper = await getWrapper(useGlobalLeaflet);
+  it(`creates a Leaflet object with expected properties`, async () => {
+    const wrapper = await getWrapper();
 
     expect(wrapper.vm.leafletObject).to.exist;
     const leafletObject = wrapper.vm.leafletObject!;
@@ -50,8 +46,8 @@ describe.each([true, false])("LControlAttribution", (useGlobalLeaflet) => {
     expect(leafletObject?.options.position).to.equal("topright");
   });
 
-  it(`registers its Leaflet object, with useGlobalLeaflet ${useGlobalLeaflet}`, async () => {
-    const wrapper = await getWrapper(useGlobalLeaflet);
+  it(`registers its Leaflet object`, async () => {
+    const wrapper = await getWrapper();
 
     expect(mockRegisterControl).toHaveBeenCalledTimes(1);
     expect(mockRegisterControl).toHaveBeenCalledWith({
@@ -59,8 +55,8 @@ describe.each([true, false])("LControlAttribution", (useGlobalLeaflet) => {
     });
   });
 
-  it(`updates the prefix, with useGlobalLeaflet ${useGlobalLeaflet}`, async () => {
-    const wrapper = await getWrapper(useGlobalLeaflet);
+  it(`updates the prefix`, async () => {
+    const wrapper = await getWrapper();
     expect(wrapper.vm.leafletObject?.options.prefix);
 
     wrapper.setProps({ prefix: "new prefix" });
@@ -69,8 +65,8 @@ describe.each([true, false])("LControlAttribution", (useGlobalLeaflet) => {
     expect(wrapper.vm.leafletObject?.options.prefix).to.equal("new prefix");
   });
 
-  it(`updates the position, with useGlobalLeaflet ${useGlobalLeaflet}`, async () => {
-    const wrapper = await getWrapper(useGlobalLeaflet);
+  it(`updates the position`, async () => {
+    const wrapper = await getWrapper();
 
     wrapper.setProps({ position: "bottomleft" });
 
@@ -78,8 +74,8 @@ describe.each([true, false])("LControlAttribution", (useGlobalLeaflet) => {
     expect(wrapper.vm.leafletObject?.options.position).to.equal("bottomleft");
   });
 
-  it(`removes itself from the map on unmount, with useGlobalLeaflet ${useGlobalLeaflet}`, async () => {
-    const wrapper = await getWrapper(useGlobalLeaflet);
+  it(`removes itself from the map on unmount`, async () => {
+    const wrapper = await getWrapper();
     const removeSpy = vi.spyOn(wrapper.vm.leafletObject!, "remove");
 
     wrapper.unmount();


### PR DESCRIPTION
Why?:

  - Instead of inject a boolean then doing exactly the same conditional logic in 20 odd components, just do it all in one place.
  - Avoids that injection and refs to WINDOW_OR_GLOBAL in all components, making code clearer.
  - Aside: I believe I observed a race in the wild where WINDOW_OR_GLOBAL.L was referenced in some component's onMounted but LMap.onMounted hadn't set WINDOW_OR_GLOBAL.L yet. onMounted aren't guaranteed to run sequentially or even started sequentially AFAIK. This change solves that too.
  - 
