### PR TITLE
gracefully fail dynamic marker image imports

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,19 +97,23 @@ export const remapEvents = (contextAttrs: Data): ListenersAndAttrs => {
 };
 
 export const resetWebpackIcon = async (Icon) => {
-  const modules = await Promise.all([
-    import("leaflet/dist/images/marker-icon-2x.png"),
-    import("leaflet/dist/images/marker-icon.png"),
-    import("leaflet/dist/images/marker-shadow.png"),
-  ]);
+  try {
+    const modules = await Promise.all([
+      import("leaflet/dist/images/marker-icon-2x.png"),
+      import("leaflet/dist/images/marker-icon.png"),
+      import("leaflet/dist/images/marker-shadow.png"),
+    ]);
 
-  delete Icon.Default.prototype._getIconUrl;
+    delete Icon.Default.prototype._getIconUrl;
 
-  Icon.Default.mergeOptions({
-    iconRetinaUrl: modules[0].default,
-    iconUrl: modules[1].default,
-    shadowUrl: modules[2].default,
-  });
+    Icon.Default.mergeOptions({
+      iconRetinaUrl: modules[0].default,
+      iconUrl: modules[1].default,
+      shadowUrl: modules[2].default,
+    });
+  } catch (err) {
+    console.warn(`Failed setting default marker icons`, err)
+  }
 };
 
 /**


### PR DESCRIPTION
This PR will gracefully handle errors from dynamic importing of marker icons.

This error is only appears when __NOT__ using a js bundler (i.e. when using vanilla js and importmap).

In a vanilla js context `import()` of [non-js resources is unsupported](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) and the current handling within `resetWebpackIcon` (which seems only bundler related) raises errors which makes using this library impossible.

This fix seems like a band aid, maybe it would be possible to avoid running `resetWebpackIcon` in a non-bundler context?

