### PR TITLE
Improve README with reference to use useGlobalLeaflet on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ export default {
 <style></style>
 ```
 
+If you are on Linux, make sure to add the `:useGlobalLeaflet="false"` attribute to your `l-map` component, or
+[vite will otherwise fail](https://github.com/vue-leaflet/vue-leaflet/issues/339).
+
 ### Component playground
 
 To see the [component playground](https://github.com/vue-leaflet/vue-leaflet/tree/master/src/playground/views) in action,


### PR DESCRIPTION
If you don't use `:useGlobalLeaflet="false"` on Linux, vite will fail miserably.

This pull request just adds this extremely important notice to the README.