### PR TITLE
Add missing names on components

### DIFF
--- a/src/components/LFeatureGroup.vue
+++ b/src/components/LFeatureGroup.vue
@@ -26,6 +26,7 @@ import {
 } from "@src/utils.js";
 
 export default defineComponent({
+  name: "LFeatureGroup",
   props: featureGroupProps,
   setup(props, context) {
     const leafletObject = ref<L.FeatureGroup>();

--- a/src/components/LGeoJson.vue
+++ b/src/components/LGeoJson.vue
@@ -23,6 +23,7 @@ import {
 } from "@src/utils.js";
 
 export default defineComponent({
+  name: "LGeoJson",
   props: geoJSONProps,
   setup(props, context) {
     const leafletObject = ref<L.GeoJSON>();

--- a/src/components/LGridLayer.vue
+++ b/src/components/LGridLayer.vue
@@ -29,6 +29,7 @@ import {
 } from "@src/utils.js";
 
 export default defineComponent({
+  name: "LGridLayer",
   props: {
     ...gridLayerProps,
     childRender: {

--- a/src/components/LLayerGroup.vue
+++ b/src/components/LLayerGroup.vue
@@ -23,6 +23,7 @@ import {
 } from "@src/utils.js";
 
 export default defineComponent({
+  name: "LLayerGroup",
   props: layerGroupProps,
   setup(props, context) {
     const leafletObject = ref<L.LayerGroup>();

--- a/src/components/LMap.vue
+++ b/src/components/LMap.vue
@@ -159,6 +159,7 @@ const mapProps = {
 };
 
 export default defineComponent({
+  name: "LMap",
   inheritAttrs: false,
   emits: ["ready", "update:zoom", "update:center", "update:bounds"],
   props: mapProps,

--- a/src/components/LTileLayer.vue
+++ b/src/components/LTileLayer.vue
@@ -22,6 +22,7 @@ import {
 } from "@src/utils.js";
 
 export default defineComponent({
+  name: "LTileLayer",
   props: tileLayerProps,
   setup(props, context) {
     const leafletObject = ref<L.TileLayer>();

--- a/src/components/LWmsTileLayer.vue
+++ b/src/components/LWmsTileLayer.vue
@@ -25,6 +25,7 @@ import {
 } from "@src/utils.js";
 
 export default defineComponent({
+  name: "LWMSTileLayer",
   props: wmsTileLayerProps,
   setup(props, context) {
     const leafletObject = ref<L.TileLayer.WMS>();


### PR DESCRIPTION
I got some problems testing components that relies on vue-leaflet, all vue-leaflet components without name got stubbed to `anonymous-stub` making hard to stub adequately and ultimately breaking the tests. 

This PR add the missing names.